### PR TITLE
Add 2 exceptions to gitignore for .travis and .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 target
 .*
+!.gitignore
+!.travis.yml
 *.iml
 /data
 /release


### PR DESCRIPTION
Add two exceptions to the .* for travis and gitignore, fixes warnings in IDEs.