### PR TITLE
Add configurable max window size

### DIFF
--- a/src/main/java/org/snomed/snowstorm/rest/ConceptController.java
+++ b/src/main/java/org/snomed/snowstorm/rest/ConceptController.java
@@ -18,6 +18,7 @@ import org.snomed.snowstorm.core.data.services.pojo.ResultMapPage;
 import org.snomed.snowstorm.core.pojo.BranchTimepoint;
 import org.snomed.snowstorm.rest.pojo.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
@@ -55,6 +56,10 @@ public class ConceptController {
 
 	@Autowired
 	private VersionControlHelper versionControlHelper;
+
+	@Value("${elasticsearch.max_window_size}")
+	private int elasticsearchMaxWindowSize;
+
 
 	@RequestMapping(value = "/{branch}/concepts", method = RequestMethod.GET, produces = {"application/json", "text/csv"})
 	@ResponseBody
@@ -307,8 +312,8 @@ public class ConceptController {
 	}
 
 	private void validatePageSize(@RequestParam(required = false, defaultValue = "50") int limit) {
-		if (limit > 10_000) {
-			throw new IllegalArgumentException("Maximum page size is 10000.");
+		if (limit > elasticsearchMaxWindowSize) {
+			throw new IllegalArgumentException("Maximum page size is " + elasticsearchMaxWindowSize + ".");
 		}
 	}
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -42,6 +42,9 @@ elasticsearch.username=
 # Password used to access Elasticsearch (if required)
 elasticsearch.password=
 
+# Max window size for Elasticsearch indexes
+elasticsearch.max_window_size=10000
+
 
 # ----------------------------------------
 # Security


### PR DESCRIPTION
Hello,
This makes the maximum page size configurable.
This is useful when you need to get more than 10000 results from an ECL query for example. (provided you also increase the max window size in the relevant indexes in Elasticsearch).

Another workaround would be to instead use Elasticsearch's scroll API in Snowstorm, but that seems like overkill since that doesn't happen that often.