### PR TITLE
added config and dependencies for request signing with aws credentials

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,6 +25,14 @@ snowstorm.rest-api.allowUnlimitedConceptPagination=false
 cloud.aws.region.auto=false
 cloud.aws.region.static=us-east-1
 
+# ----------------------------------------
+# AWS Request Signing
+# When using AWS Elasticsearch Service, Snowstorm requires http signing to be able to communicate with ES
+# See https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-request-signing.html
+# Disabled by default
+# ----------------------------------------
+
+snowstorm.aws.request-signing.enabled=false
 
 # ----------------------------------------
 # Elasticsearch Data Store


### PR DESCRIPTION
Using AWS ElasticSearch Service posed some issues to us. Using IAM Users for our domain access policy, we were unable to connect to the elasticsearch service. This required requests to be signed. 
https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-request-signing.html

this seems like a nice feature to have, and it is quite standard to use IAM access policies for AWS services. 

Using default providers, the config for region, accessKeyId & accessKeySecret can be injected with environment variables.
AWS_REGION
AWS_ACCESS_KEY_ID
AWS_SECRET_KEY