### PR TITLE
Make browser/{branch}/concepts/bulk-load accessible in read-only mode…

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,6 +14,9 @@
 # REST API read only mode
 # This disables any POST/PUT/PATCH/DELETE methods and also hides endpoints which are only relevant during authoring.
 snowstorm.rest-api.readonly=false
+# This disables read-only POST endpoints when snowstorm.rest-api.readonly is true. Needed to protect the public
+# Snowstorm server from heavy POST requests, even if they are read-only. Private installations may want to enable such endpoints.
+snowstorm.rest-api.readonly.allowReadOnlyPostEndpoints=false
 
 # Allow unlimited pagination of full concept representation
 snowstorm.rest-api.allowUnlimitedConceptPagination=false


### PR DESCRIPTION
… when a newly introduced flag is enabled.

This is the result of the decision made in this discussion:
https://github.com/IHTSDO/snowstorm/pull/82

We need to make the "browser/{branch}/concepts/bulk-load " endpoint accessible in read-only mode, but we need to introduce a new flag for it, because the Snowstorm team doesn't want this endpoint to be accessible in the public server even though it's read-only, because sometimes people try to load most of SNOMED from their public browser. Thus this flag is needed to make the switch for private installations.