### PR TITLE
Fix MAINT-1322, Rewrite of historical association merge.

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/services/ConceptUpdateHelper.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/ConceptUpdateHelper.java
@@ -361,21 +361,26 @@ public class ConceptUpdateHelper extends ComponentService {
 
 	private ReferenceSetMember getBestRefsetMember(String refsetId, String additionalFieldKey, String additionalFieldValue, Set<ReferenceSetMember> newVersionMembers, Set<ReferenceSetMember> existingVersionMembers) {
 		ReferenceSetMember bestMember = null;
-		bestMember = getBestRefsetMemberInSetOrKeep(refsetId, additionalFieldKey, additionalFieldValue, existingVersionMembers, bestMember);
-		bestMember = getBestRefsetMemberInSetOrKeep(refsetId, additionalFieldKey, additionalFieldValue, newVersionMembers, bestMember);
+		if (existingVersionMembers != null) {
+			bestMember = getBestRefsetMemberInSetOrKeep(refsetId, additionalFieldKey, additionalFieldValue, existingVersionMembers, bestMember);
+		}
+		if (newVersionMembers != null) {
+			bestMember = getBestRefsetMemberInSetOrKeep(refsetId, additionalFieldKey, additionalFieldValue, newVersionMembers, bestMember);
+		}
 		return bestMember;
 	}
 
-	private ReferenceSetMember getBestRefsetMemberInSetOrKeep(String refsetId, String additionalFieldKey, String requiredValue, Set<ReferenceSetMember> members, ReferenceSetMember candidate) {
-		if (members != null) {
-			for (ReferenceSetMember newVersionMember : members) {
-				final String actualValue = newVersionMember.getAdditionalField(additionalFieldKey);
-				if (refsetId.equals(newVersionMember.getRefsetId()) && requiredValue.equals(actualValue)) {
-					if (candidate != null) {
-						// return original candidate if it is stronger in terms released and active flags
-						return REFERENCE_SET_MEMBER_COMPARATOR_BY_RELEASED.compare(candidate, newVersionMember) > 0 ? candidate : newVersionMember;
+	private ReferenceSetMember getBestRefsetMemberInSetOrKeep(String refsetId, String additionalFieldKey, String requiredValue, Collection<ReferenceSetMember> members, ReferenceSetMember candidate) {
+		for (ReferenceSetMember newVersionMember : members) {
+			final String actualValue = newVersionMember.getAdditionalField(additionalFieldKey);
+			if (refsetId.equals(newVersionMember.getRefsetId()) && requiredValue.equals(actualValue)) {
+				if (candidate == null) {
+					candidate = newVersionMember;
+				} else {
+					// only replace candidate if it is stronger in terms released and active flags
+					if (REFERENCE_SET_MEMBER_COMPARATOR_BY_RELEASED.compare(candidate, newVersionMember) < 0) {
+						candidate = newVersionMember;
 					}
-					return newVersionMember;
 				}
 			}
 		}

--- a/src/main/java/org/snomed/snowstorm/core/data/services/ConceptUpdateHelper.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/ConceptUpdateHelper.java
@@ -17,7 +17,7 @@ import org.snomed.snowstorm.core.data.services.identifier.IdentifierReservedBloc
 import org.snomed.snowstorm.core.data.services.identifier.IdentifierService;
 import org.snomed.snowstorm.core.data.services.pojo.PersistedComponents;
 import org.snomed.snowstorm.core.util.DescriptionHelper;
-import org.snomed.snowstorm.core.util.MapUtil;
+import org.snomed.snowstorm.core.util.SetUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHitsIterator;
@@ -39,6 +39,7 @@ import static org.snomed.snowstorm.core.data.services.ConceptService.DISABLE_CON
 @Service
 public class ConceptUpdateHelper extends ComponentService {
 
+	public static final Comparator<ReferenceSetMember> REFERENCE_SET_MEMBER_COMPARATOR_BY_RELEASED = Comparator.comparing(ReferenceSetMember::isReleased).thenComparing(ReferenceSetMember::isActive);
 	@Autowired
 	private ConceptRepository conceptRepository;
 
@@ -296,59 +297,89 @@ public class ConceptUpdateHelper extends ComponentService {
 		}
 	}
 
-	private void updateAssociations(SnomedComponentWithAssociations newComponent, SnomedComponentWithAssociations existingComponent, List<ReferenceSetMember> refsetMembersToPersist) {
-		Map<String, Set<String>> newAssociations = newComponent.getAssociationTargets();
-		Map<String, Set<String>> existingAssociations = existingComponent == null ? null : existingComponent.getAssociationTargets();
-		if (existingAssociations != null && !MapUtil.containsAllKeysAndSetsAreSupersets(newAssociations, existingAssociations)) {
-			// One or more existing associations need to be made inactive
+	private void updateAssociations(SnomedComponentWithAssociations newComponentVersion, SnomedComponentWithAssociations existingComponentVersion, List<ReferenceSetMember> refsetMembersToPersist) {
 
-			if (newAssociations == null) {
-				newAssociations = new HashMap<>();
+		Map<String, Set<String>> newVersionAssociations = newComponentVersion.getAssociationTargets();
+		if (newVersionAssociations == null) {
+			newVersionAssociations = new HashMap<>();
+		}
+		final Set<ReferenceSetMember> newVersionMembers = newComponentVersion.getAssociationTargetMembers();
+		final Set<ReferenceSetMember> existingVersionMembers = existingComponentVersion != null ? existingComponentVersion.getAssociationTargetMembers() : Collections.emptySet();
+
+		// New component version doesn't have refset members joined, it may have come from the REST API
+		// Attempt to match existing members to the association target key/value map
+		// Inactivate members which are no longer needed
+		// Create members which are in the key/value map but do not yet exist
+		Set<ReferenceSetMember> membersToKeep = new HashSet<>();
+		Set<ReferenceSetMember> membersToCreate = new HashSet<>();
+		Set<ReferenceSetMember> membersToRetire = new HashSet<>();
+		for (String associationTypeName : newVersionAssociations.keySet()) {
+			String associationRefsetId = Concepts.historicalAssociationNames.inverse().get(associationTypeName);
+			for (String associationValue : newVersionAssociations.get(associationTypeName)) {
+
+				ReferenceSetMember bestMember = getBestRefsetMember(associationRefsetId, ReferenceSetMember.AssociationFields.TARGET_COMP_ID, associationValue, newVersionMembers, existingVersionMembers);
+				if (bestMember != null) {
+					// Keep
+					membersToKeep.add(bestMember);
+				} else {
+					// Create new
+					bestMember = new ReferenceSetMember(newComponentVersion.getModuleId(), associationRefsetId, newComponentVersion.getId());
+					bestMember.setAdditionalField(ReferenceSetMember.AssociationFields.TARGET_COMP_ID, associationValue);
+					membersToCreate.add(bestMember);
+				}
+				bestMember.setActive(true);
+				newComponentVersion.addAssociationTargetMember(bestMember);
 			}
-			// Check each association type
-			for (String associationName : existingAssociations.keySet()) {
-				// Associations for this type on both sides
-				Set<String> existingAssociationsOfType = existingAssociations.get(associationName);
-				Set<String> newAssociationsOfType = newAssociations.get(associationName);
-				// Iterate existing set
-				for (String existingAssociationTarget : existingAssociationsOfType) {
-					// If new set doesn't exist or doesn't contain existing association make it inactive.
-					if (newAssociationsOfType == null || !newAssociationsOfType.contains(existingAssociationTarget)) {
-						// Existing association should be made inactive
-						// Find the refset member for this association concept id and target concept id
-						String associationRefsetId = Concepts.historicalAssociationNames.inverse().get(associationName);
-						for (ReferenceSetMember existingMember : Optional.ofNullable(existingComponent.getAssociationTargetMembers()).orElse(Collections.emptySet())) {
-							if (existingMember.isActive() && existingMember.getRefsetId().equals(associationRefsetId)
-									&& existingAssociationTarget.equals(existingMember.getAdditionalField(ReferenceSetMember.AssociationFields.TARGET_COMP_ID))) {
-								existingMember.setActive(false);
-								existingMember.markChanged();
-								refsetMembersToPersist.add(existingMember);
-							}
-						}
+		}
+
+		// Persist new
+		membersToCreate.forEach(member -> {
+			member.markChanged();
+			refsetMembersToPersist.add(member);
+		});
+
+		// Persist winners
+		membersToKeep.forEach(member -> {
+			if (!member.isActive()) {
+				member.setActive(true);
+				member.markChanged();
+				refsetMembersToPersist.add(member);
+			}
+		});
+
+		// Retire all others
+		membersToRetire.addAll(SetUtils.remainder(newVersionMembers, membersToKeep));
+		membersToRetire.addAll(SetUtils.remainder(existingVersionMembers, membersToKeep));
+		membersToRetire.forEach(member -> {
+			if (member.isActive()) {
+				member.setActive(false);
+				member.markChanged();
+				refsetMembersToPersist.add(member);
+			}
+		});
+	}
+
+	private ReferenceSetMember getBestRefsetMember(String refsetId, String additionalFieldKey, String additionalFieldValue, Set<ReferenceSetMember> newVersionMembers, Set<ReferenceSetMember> existingVersionMembers) {
+		ReferenceSetMember bestMember = null;
+		bestMember = getBestRefsetMemberInSetOrKeep(refsetId, additionalFieldKey, additionalFieldValue, existingVersionMembers, bestMember);
+		bestMember = getBestRefsetMemberInSetOrKeep(refsetId, additionalFieldKey, additionalFieldValue, newVersionMembers, bestMember);
+		return bestMember;
+	}
+
+	private ReferenceSetMember getBestRefsetMemberInSetOrKeep(String refsetId, String additionalFieldKey, String requiredValue, Set<ReferenceSetMember> members, ReferenceSetMember candidate) {
+		if (members != null) {
+			for (ReferenceSetMember newVersionMember : members) {
+				final String actualValue = newVersionMember.getAdditionalField(additionalFieldKey);
+				if (refsetId.equals(newVersionMember.getRefsetId()) && requiredValue.equals(actualValue)) {
+					if (candidate != null) {
+						// return original candidate if it is stronger in terms released and active flags
+						return REFERENCE_SET_MEMBER_COMPARATOR_BY_RELEASED.compare(candidate, newVersionMember) > 0 ? candidate : newVersionMember;
 					}
+					return newVersionMember;
 				}
 			}
 		}
-		if (newAssociations != null) {
-			Map<String, Set<String>> missingKeyValues = MapUtil.collectMissingKeyValues(existingAssociations, newAssociations);
-			if (!missingKeyValues.isEmpty()) {
-				// One or more new associations need to be created
-				for (String associationName : missingKeyValues.keySet()) {
-					Set<String> missingValues = missingKeyValues.get(associationName);
-					for (String missingValue : missingValues) {
-						String associationRefsetId = Concepts.historicalAssociationNames.inverse().get(associationName);
-						if (associationRefsetId == null) {
-							throw new IllegalArgumentException("Association reference set not recognised '" + associationName + "'.");
-						}
-						ReferenceSetMember newTargetMember = new ReferenceSetMember(newComponent.getModuleId(), associationRefsetId, newComponent.getId());
-						newTargetMember.setAdditionalField("targetComponentId", missingValue);
-						newTargetMember.markChanged();
-						refsetMembersToPersist.add(newTargetMember);
-						newComponent.addAssociationTargetMember(newTargetMember);
-					}
-				}
-			}
-		}
+		return candidate;
 	}
 
 	private void updateInactivationIndicator(SnomedComponentWithInactivationIndicator newComponent,

--- a/src/main/java/org/snomed/snowstorm/core/util/SetUtils.java
+++ b/src/main/java/org/snomed/snowstorm/core/util/SetUtils.java
@@ -1,0 +1,25 @@
+package org.snomed.snowstorm.core.util;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class SetUtils {
+	/**
+	 * Returns a new set containing the items from the first set which remain after the items from the second set are removed.
+	 * Either set can be null. If the first set is null an empty set will be returned.
+	 * @param items        	The set to work on.
+	 * @param itemsToRemove	The set of items to remove.
+	 * @return A new set containing the items in the first set after items from the second set are removed.
+	 */
+	public static <T> Set<T> remainder(Set<T> items, Set<T> itemsToRemove) {
+		if (items == null) {
+			return Collections.emptySet();
+		}
+		Set<T> itemsCopy = new HashSet<>(items);
+		if (itemsToRemove != null) {
+			itemsCopy.removeAll(itemsToRemove);
+		}
+		return itemsCopy;
+	}
+}


### PR DESCRIPTION
Merging of the historical associations of a concept or description can happen either by saving a new version of a concept through the API or by merging two branches together. When merging two branches we were finding that duplicate records were created because two refset members with the same refset id and association target existed on both sides of the merge. We try to favour the released and active records so a comparator is now used for this.