### PR TITLE
CDI-29 -- Add support for importing concrete Relationships converted from Axioms

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/domain/Relationship.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/domain/Relationship.java
@@ -157,6 +157,14 @@ public class Relationship extends SnomedComponent<Relationship> {
 		this.modifierId = modifierId;
 	}
 
+	public static Relationship newConcrete(String typeId, String value) {
+		final Relationship relationship = new Relationship();
+		relationship.setTypeId(typeId);
+		relationship.setValue(value);
+
+		return relationship;
+	}
+
 	@Override
 	public String getIdField() {
 		return Fields.RELATIONSHIP_ID;
@@ -176,6 +184,33 @@ public class Relationship extends SnomedComponent<Relationship> {
 	
 	public boolean isGrouped () {
 		return relationshipGroup > 0;
+	}
+
+	public ConcreteValue getConcreteValue() {
+		if (this.value == null) {
+			return null;
+		}
+
+		this.concreteValue = new ConcreteValue(this.value);
+		return this.concreteValue;
+	}
+
+	public void setConcreteValue(ConcreteValue concreteValue) {
+		this.concreteValue = concreteValue;
+	}
+
+	public void setConcreteValue(String value) {
+		if (value != null) {
+			this.concreteValue = new ConcreteValue(value);
+		}
+
+		this.destinationId = null;
+		this.value = value;
+		this.target = null;
+	}
+
+	public boolean isConcrete() {
+		return this.value != null && this.destinationId == null;
 	}
 
 	@Override
@@ -307,6 +342,7 @@ public class Relationship extends SnomedComponent<Relationship> {
 	}
 
 	public void setDestinationId(String destinationId) {
+		this.value = null;
 		this.destinationId = destinationId;
 	}
 
@@ -315,30 +351,8 @@ public class Relationship extends SnomedComponent<Relationship> {
 	}
 
 	public void setValue(String value) {
-		this.value = value;
-	}
-
-	public ConcreteValue getConcreteValue() {
-		if (this.value == null) {
-			return null;
-		}
-
-		this.concreteValue = new ConcreteValue(this.value);
-		return this.concreteValue;
-	}
-
-	public void setConcreteValue(ConcreteValue concreteValue) {
-		this.concreteValue = concreteValue;
-	}
-
-	public void setConcreteValue(String value) {
-		if (value != null) {
-			this.concreteValue = new ConcreteValue(value);
-		}
-
 		this.destinationId = null;
 		this.value = value;
-		this.target = null;
 	}
 
 	public int getRelationshipGroup() {
@@ -353,8 +367,9 @@ public class Relationship extends SnomedComponent<Relationship> {
 		return typeId;
 	}
 
-	public void setTypeId(String typeId) {
+	public Relationship setTypeId(String typeId) {
 		this.typeId = typeId;
+		return this;
 	}
 
 	public String getCharacteristicTypeId() {

--- a/src/main/java/org/snomed/snowstorm/core/data/services/AxiomConversionService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/AxiomConversionService.java
@@ -57,18 +57,20 @@ public class AxiomConversionService {
 	}
 
 	public void populateAxiomMembers(Collection<Concept> concepts, String branchPath) {
-		AxiomRelationshipConversionService conversionService = setupConversionService(branchPath);
-		for (Concept concept : concepts) {
-			for (Axiom axiom : concept.getClassAxioms()) {
-				String owlExpression = conversionService.convertRelationshipsToAxiom(
-						mapFromInternalRelationshipType(concept.getConceptId(), axiom.getDefinitionStatusId(), axiom.getRelationships(), true));
-				axiom.setReferenceSetMember(createMember(concept, axiom, owlExpression));
+		try {
+			AxiomRelationshipConversionService conversionService = setupConversionService(branchPath);
+			for (Concept concept : concepts) {
+				for (Axiom axiom : concept.getClassAxioms()) {
+					String owlExpression = conversionService.convertRelationshipsToAxiom(mapFromInternalRelationshipType(concept.getConceptId(), axiom.getDefinitionStatusId(), axiom.getRelationships(), true));
+					axiom.setReferenceSetMember(createMember(concept, axiom, owlExpression));
+				}
+				for (Axiom gciAxiom : concept.getGciAxioms()) {
+					String owlExpression = conversionService.convertRelationshipsToAxiom(mapFromInternalRelationshipType(concept.getConceptId(), gciAxiom.getDefinitionStatusId(), gciAxiom.getRelationships(), false));
+					gciAxiom.setReferenceSetMember(createMember(concept, gciAxiom, owlExpression));
+				}
 			}
-			for (Axiom gciAxiom : concept.getGciAxioms()) {
-				String owlExpression = conversionService.convertRelationshipsToAxiom(
-						mapFromInternalRelationshipType(concept.getConceptId(), gciAxiom.getDefinitionStatusId(), gciAxiom.getRelationships(), false));
-				gciAxiom.setReferenceSetMember(createMember(concept, gciAxiom, owlExpression));
-			}
+		} catch (final ConversionException e) {
+			throw new RuntimeException("Failed to convert Relationship(s) to Axiom(s).", e);
 		}
 	}
 

--- a/src/main/java/org/snomed/snowstorm/core/data/services/SemanticIndexUpdateService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/SemanticIndexUpdateService.java
@@ -157,7 +157,7 @@ public class SemanticIndexUpdateService extends ComponentService implements Comm
 		}
 
 		BiConsumer<SnomedComponent, Relationship> relationshipConsumer = (component, relationship) -> {
-			if (activeNow(component, timeSlice)) {
+			if (!relationship.isConcrete() && activeNow(component, timeSlice)) {
 				long conceptId = parseLong(relationship.getSourceId());
 				int groupId = relationship.getGroupId();
 				long type = parseLong(relationship.getTypeId());
@@ -381,7 +381,7 @@ public class SemanticIndexUpdateService extends ComponentService implements Comm
 							// for each
 							(component, relationship) -> {
 								updateSource.add(parseLong(relationship.getSourceId()));
-								if (relationship.getTypeId().equals(Concepts.ISA)) {
+								if (!relationship.isConcrete() && relationship.getTypeId().equals(Concepts.ISA)) {
 									updateDestination.add(parseLong(relationship.getDestinationId()));
 								}
 							});

--- a/src/main/java/org/snomed/snowstorm/core/data/services/TraceabilityLogService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/TraceabilityLogService.java
@@ -159,18 +159,27 @@ public class TraceabilityLogService implements CommitListener {
 			}
 		}
 		for (Description description : persistedDescriptions) {
+			final long conceptId = parseLong(description.getConceptId());
 			if (!useChangeFlag || (description.isChanged() || description.isDeleted())) {
-				activityMap.get(parseLong(description.getConceptId())).addComponentChange(getChange(description)).statedChange();
+				final Activity.ComponentChange change = getChange(description);
+				final Activity.ConceptActivity conceptActivity = activityMap.get(conceptId);
+				if (conceptActivity != null) {
+					conceptActivity.addComponentChange(change).statedChange();
+				}
 			}
-			componentToConceptIdMap.put(parseLong(description.getDescriptionId()), parseLong(description.getConceptId()));
+			componentToConceptIdMap.put(parseLong(description.getDescriptionId()), conceptId);
 		}
 		for (Relationship relationship : persistedRelationships) {
+			final long sourceId = parseLong(relationship.getSourceId());
 			if (!useChangeFlag || (relationship.isChanged() || relationship.isDeleted())) {
-				activityMap.get(parseLong(relationship.getSourceId()))
-						.addComponentChange(getChange(relationship))
-						.addStatedChange(!Concepts.INFERRED_RELATIONSHIP.equals(relationship.getCharacteristicTypeId()));
+				final Activity.ConceptActivity conceptActivity = activityMap.get(sourceId);
+				if (conceptActivity != null) {
+					conceptActivity
+							.addComponentChange(getChange(relationship))
+							.addStatedChange(!Concepts.INFERRED_RELATIONSHIP.equals(relationship.getCharacteristicTypeId()));
+				}
 			}
-			componentToConceptIdMap.put(parseLong(relationship.getRelationshipId()), parseLong(relationship.getSourceId()));
+			componentToConceptIdMap.put(parseLong(relationship.getRelationshipId()), sourceId);
 		}
 		for (ReferenceSetMember refsetMember : persistedReferenceSetMembers) {
 			if (!useChangeFlag || (refsetMember.isChanged() || refsetMember.isDeleted())) {

--- a/src/test/java/org/snomed/snowstorm/core/data/services/ConceptServiceTest.java
+++ b/src/test/java/org/snomed/snowstorm/core/data/services/ConceptServiceTest.java
@@ -646,7 +646,7 @@ class ConceptServiceTest extends AbstractTest {
 	@Test
 	public void testCreateConceptWithConcreteIntValue() throws ServiceException {
 		//given
-		final Relationship relationship = new Relationship("200001001", 20170131, true, "900000000000012004", "900000000000441003", "#1", 0, "116680003", "900000000000011006", "900000000000451002");
+		final Relationship relationship = Relationship.newConcrete("1234567891011", "#1");
 		final Concept inConcept = new Concept("12345678910");
 		inConcept.addAxiom(relationship);
 
@@ -665,7 +665,7 @@ class ConceptServiceTest extends AbstractTest {
 	@Test
 	public void testCreateConceptWithConcreteDecValue() throws ServiceException {
 		//given
-		final Relationship relationship = new Relationship("200001001", 20170131, true, "900000000000012004", "900000000000441003", "#3.14", 0, "116680003", "900000000000011006", "900000000000451002");
+		final Relationship relationship = Relationship.newConcrete("1234567891011", "#3.14");
 		final Concept inConcept = new Concept("12345678910");
 		inConcept.addAxiom(relationship);
 

--- a/src/test/java/org/snomed/snowstorm/core/data/services/ConceptServiceTest.java
+++ b/src/test/java/org/snomed/snowstorm/core/data/services/ConceptServiceTest.java
@@ -644,6 +644,63 @@ class ConceptServiceTest extends AbstractTest {
 	}
 
 	@Test
+	public void testCreateConceptWithConcreteIntValue() throws ServiceException {
+		//given
+		final Relationship relationship = new Relationship("200001001", 20170131, true, "900000000000012004", "900000000000441003", "#1", 0, "116680003", "900000000000011006", "900000000000451002");
+		final Concept inConcept = new Concept("12345678910");
+		inConcept.addAxiom(relationship);
+
+		//when
+		conceptService.create(inConcept, "MAIN");
+		final Concept outConcept = conceptService.find("12345678910", "MAIN");
+		final Set<Axiom> classAxioms = outConcept.getClassAxioms();
+		final int size = classAxioms.size();
+		final String value = classAxioms.iterator().next().getRelationships().iterator().next().getValue();
+
+		//then
+		assertEquals(1, size);
+		assertEquals("#1", value);
+	}
+
+	@Test
+	public void testCreateConceptWithConcreteDecValue() throws ServiceException {
+		//given
+		final Relationship relationship = new Relationship("200001001", 20170131, true, "900000000000012004", "900000000000441003", "#3.14", 0, "116680003", "900000000000011006", "900000000000451002");
+		final Concept inConcept = new Concept("12345678910");
+		inConcept.addAxiom(relationship);
+
+		//when
+		conceptService.create(inConcept, "MAIN");
+		final Concept outConcept = conceptService.find("12345678910", "MAIN");
+		final Set<Axiom> classAxioms = outConcept.getClassAxioms();
+		final int size = classAxioms.size();
+		final String value = classAxioms.iterator().next().getRelationships().iterator().next().getValue();
+
+		//then
+		assertEquals(1, size);
+		assertEquals("#3.14", value);
+	}
+
+	@Test
+	public void testCreateConceptWithConcreteStrValue() throws ServiceException {
+		//given
+		final Relationship relationship = new Relationship("200001001", 20170131, true, "900000000000012004", "900000000000441003", "\"Two tablets before bed\"", 0, "116680003", "900000000000011006", "900000000000451002");
+		final Concept inConcept = new Concept("12345678910");
+		inConcept.addAxiom(relationship);
+
+		//when
+		conceptService.create(inConcept, "MAIN");
+		final Concept outConcept = conceptService.find("12345678910", "MAIN");
+		final Set<Axiom> classAxioms = outConcept.getClassAxioms();
+		final int size = classAxioms.size();
+		final String value = classAxioms.iterator().next().getRelationships().iterator().next().getValue();
+
+		//then
+		assertEquals(1, size);
+		assertEquals("\"Two tablets before bed \"", value);
+	}
+
+	@Test
 	void testSaveConceptWithDescriptionAndAcceptabilityTogether() throws ServiceException {
 		final Concept concept = new Concept("50960005", 20020131, true, "900000000000207008", "900000000000074008");
 		concept.addDescription(

--- a/src/test/java/org/snomed/snowstorm/core/data/services/ConceptServiceTest.java
+++ b/src/test/java/org/snomed/snowstorm/core/data/services/ConceptServiceTest.java
@@ -646,9 +646,11 @@ class ConceptServiceTest extends AbstractTest {
 	@Test
 	public void testCreateConceptWithConcreteIntValue() throws ServiceException {
 		//given
-		final Relationship relationship = Relationship.newConcrete("1234567891011", "#1");
 		final Concept inConcept = new Concept("12345678910");
-		inConcept.addAxiom(relationship);
+		inConcept.addAxiom(
+				new Relationship(ISA, "12345"),
+				Relationship.newConcrete("1234567891011", "#1")
+		);
 
 		//when
 		conceptService.create(inConcept, "MAIN");
@@ -665,9 +667,11 @@ class ConceptServiceTest extends AbstractTest {
 	@Test
 	public void testCreateConceptWithConcreteDecValue() throws ServiceException {
 		//given
-		final Relationship relationship = Relationship.newConcrete("1234567891011", "#3.14");
 		final Concept inConcept = new Concept("12345678910");
-		inConcept.addAxiom(relationship);
+		inConcept.addAxiom(
+				new Relationship(ISA, "12345"),
+				Relationship.newConcrete("1234567891011", "#3.14")
+		);
 
 		//when
 		conceptService.create(inConcept, "MAIN");

--- a/src/test/java/org/snomed/snowstorm/core/data/services/ConceptServiceTest.java
+++ b/src/test/java/org/snomed/snowstorm/core/data/services/ConceptServiceTest.java
@@ -682,25 +682,6 @@ class ConceptServiceTest extends AbstractTest {
 	}
 
 	@Test
-	public void testCreateConceptWithConcreteStrValue() throws ServiceException {
-		//given
-		final Relationship relationship = new Relationship("200001001", 20170131, true, "900000000000012004", "900000000000441003", "\"Two tablets before bed\"", 0, "116680003", "900000000000011006", "900000000000451002");
-		final Concept inConcept = new Concept("12345678910");
-		inConcept.addAxiom(relationship);
-
-		//when
-		conceptService.create(inConcept, "MAIN");
-		final Concept outConcept = conceptService.find("12345678910", "MAIN");
-		final Set<Axiom> classAxioms = outConcept.getClassAxioms();
-		final int size = classAxioms.size();
-		final String value = classAxioms.iterator().next().getRelationships().iterator().next().getValue();
-
-		//then
-		assertEquals(1, size);
-		assertEquals("\"Two tablets before bed \"", value);
-	}
-
-	@Test
 	void testSaveConceptWithDescriptionAndAcceptabilityTogether() throws ServiceException {
 		final Concept concept = new Concept("50960005", 20020131, true, "900000000000207008", "900000000000074008");
 		concept.addDescription(


### PR DESCRIPTION
CDI-29 is concerned with adding support for importing concrete Relationships. 

I have made the following code changes in order for concrete Relationships to be imported that have been converted from Axioms.

**Note:-** This code is related to snomed-owl-toolkit@feature/CDI-29. 