### PR TITLE
BROWSE-241 -- View history of a Concept

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/domain/ComponentType.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/domain/ComponentType.java
@@ -1,7 +1,7 @@
 package org.snomed.snowstorm.core.data.domain;
 
 public enum ComponentType {
-	Concept, Description, Relationship;
+	Concept, Description, Relationship, Axiom;
 
 	public static ComponentType getTypeFromPartition(String partitionId) {
 		int lastDigit = Integer.parseInt(partitionId.substring(partitionId.length() - 1));

--- a/src/main/java/org/snomed/snowstorm/core/data/services/ConceptService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/ConceptService.java
@@ -163,6 +163,7 @@ public class ConceptService extends ComponentService {
 			BoolQueryBuilder boolQueryBuilder = boolQuery();
 			boolQueryBuilder.must(someReleaseBranch);
 			boolQueryBuilder.must(existsQuery(Concept.Fields.EFFECTIVE_TIME));
+			boolQueryBuilder.minimumShouldMatch(1);
 			boolQueryBuilder.should(termQuery(Concept.Fields.CONCEPT_ID, cId)); //Find for Concept, Description & Axiom (RefSetMember) documents
 			boolQueryBuilder.should(termQuery(Relationship.Fields.SOURCE_ID, cId)); //Find for Relationship documents
 

--- a/src/main/java/org/snomed/snowstorm/core/data/services/ConceptService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/ConceptService.java
@@ -56,13 +56,13 @@ import static org.springframework.util.CollectionUtils.isEmpty;
 
 @Service
 public class ConceptService extends ComponentService {
-	private static final Map<ComponentType, Class<? extends DomainEntity<?>>> DOCUMENTS = new HashMap<>();
+	private static final Map<ComponentType, Class<? extends DomainEntity<?>>> COMPONENT_DOCUMENT_TYPES = new HashMap<>();
 
 	static {
-		DOCUMENTS.put(ComponentType.Concept, Concept.class);
-		DOCUMENTS.put(ComponentType.Description, Description.class);
-		DOCUMENTS.put(ComponentType.Relationship, Relationship.class);
-		DOCUMENTS.put(ComponentType.Axiom, ReferenceSetMember.class);
+		COMPONENT_DOCUMENT_TYPES.put(ComponentType.Concept, Concept.class);
+		COMPONENT_DOCUMENT_TYPES.put(ComponentType.Description, Description.class);
+		COMPONENT_DOCUMENT_TYPES.put(ComponentType.Relationship, Relationship.class);
+		COMPONENT_DOCUMENT_TYPES.put(ComponentType.Axiom, ReferenceSetMember.class);
 	}
 
 	@Autowired
@@ -170,7 +170,7 @@ public class ConceptService extends ComponentService {
 		};
 		PageRequest pageRequest = PageRequest.of(0, codeSystemVersions.size() + 1);
 		ConceptHistory conceptHistory = new ConceptHistory(conceptId);
-		for (Map.Entry<ComponentType, Class<? extends DomainEntity<?>>> entrySet : DOCUMENTS.entrySet()) {
+		for (Map.Entry<ComponentType, Class<? extends DomainEntity<?>>> entrySet : COMPONENT_DOCUMENT_TYPES.entrySet()) {
 			ComponentType componentType = entrySet.getKey();
 			Class<? extends DomainEntity<?>> document = entrySet.getValue();
 			BoolQueryBuilder boolQueryBuilder = defaultBoolQueryFunction.apply(conceptId);

--- a/src/main/java/org/snomed/snowstorm/core/data/services/ConceptService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/ConceptService.java
@@ -172,7 +172,7 @@ public class ConceptService extends ComponentService {
 		ConceptHistory conceptHistory = new ConceptHistory(conceptId);
 		for (Map.Entry<ComponentType, Class<? extends DomainEntity<?>>> entrySet : COMPONENT_DOCUMENT_TYPES.entrySet()) {
 			ComponentType componentType = entrySet.getKey();
-			Class<? extends DomainEntity<?>> document = entrySet.getValue();
+			Class<? extends DomainEntity<?>> documentType = entrySet.getValue();
 			BoolQueryBuilder boolQueryBuilder = defaultBoolQueryFunction.apply(conceptId);
 
 			if (componentType.equals(ComponentType.Axiom)) {
@@ -185,7 +185,7 @@ public class ConceptService extends ComponentService {
 				boolQueryBuilder
 						.should(
 								boolQuery()
-										.must(branchCriteria.get(codeSystemVersion.getBranchPath()).getEntityBranchCriteria(document))
+										.must(branchCriteria.get(codeSystemVersion.getBranchPath()).getEntityBranchCriteria(documentType))
 										.must(termQuery(Concept.Fields.EFFECTIVE_TIME, codeSystemVersion.getEffectiveDate()))
 						);
 			}
@@ -195,7 +195,7 @@ public class ConceptService extends ComponentService {
 							.withQuery(boolQueryBuilder)
 							.withPageable(pageRequest)
 							.build(),
-					document
+					documentType
 			);
 			for (SearchHit<? extends DomainEntity<?>> searchHit : searchHits.getSearchHits()) {
 				if (searchHit.getContent() instanceof SnomedComponent<?>) {

--- a/src/main/java/org/snomed/snowstorm/core/data/services/ConceptService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/ConceptService.java
@@ -169,7 +169,6 @@ public class ConceptService extends ComponentService {
 
 			return boolQueryBuilder;
 		};
-		PageRequest pageRequest = PageRequest.of(0, codeSystemVersions.size() + 1);
 		ConceptHistory conceptHistory = new ConceptHistory(conceptId);
 		for (Map.Entry<ComponentType, Class<? extends DomainEntity<?>>> entrySet : COMPONENT_DOCUMENT_TYPES.entrySet()) {
 			ComponentType componentType = entrySet.getKey();
@@ -194,7 +193,7 @@ public class ConceptService extends ComponentService {
 			SearchHits<? extends DomainEntity<?>> searchHits = elasticsearchTemplate.search(
 					new NativeSearchQueryBuilder()
 							.withQuery(boolQueryBuilder)
-							.withPageable(pageRequest)
+							.withPageable(LARGE_PAGE)
 							.build(),
 					documentType
 			);

--- a/src/main/java/org/snomed/snowstorm/core/data/services/pojo/ConceptHistory.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/pojo/ConceptHistory.java
@@ -31,13 +31,6 @@ public class ConceptHistory {
     }
 
     public void addToHistory(String effectiveTime, ComponentType componentType) {
-        Set<ComponentType> componentTypes = this.history.get(effectiveTime);
-        if (componentTypes != null) {
-            componentTypes.add(componentType);
-        } else {
-            componentTypes = new HashSet<>();
-            componentTypes.add(componentType);
-            this.history.put(effectiveTime, componentTypes);
-        }
+        history.computeIfAbsent(effectiveTime, (key) -> new HashSet<>()).add(componentType);
     }
 }

--- a/src/main/java/org/snomed/snowstorm/core/data/services/pojo/ConceptHistory.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/pojo/ConceptHistory.java
@@ -1,0 +1,43 @@
+package org.snomed.snowstorm.core.data.services.pojo;
+
+import org.snomed.snowstorm.core.data.domain.ComponentType;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * History of a Concept.
+ */
+public class ConceptHistory {
+    private final String conceptId;
+    private final Map<String, Set<ComponentType>> history = new HashMap<>();
+
+    public ConceptHistory() {
+        this.conceptId = null;
+    }
+
+    public ConceptHistory(String conceptId) {
+        this.conceptId = conceptId;
+    }
+
+    public String getConceptId() {
+        return this.conceptId;
+    }
+
+    public Map<String, Set<ComponentType>> getHistory() {
+        return this.history;
+    }
+
+    public void addToHistory(String effectiveTime, ComponentType componentType) {
+        Set<ComponentType> componentTypes = this.history.get(effectiveTime);
+        if (componentTypes != null) {
+            componentTypes.add(componentType);
+        } else {
+            componentTypes = new HashSet<>();
+            componentTypes.add(componentType);
+            this.history.put(effectiveTime, componentTypes);
+        }
+    }
+}

--- a/src/main/java/org/snomed/snowstorm/rest/ConceptController.java
+++ b/src/main/java/org/snomed/snowstorm/rest/ConceptController.java
@@ -278,7 +278,7 @@ public class ConceptController {
 	}
 
 	@ApiOperation(value = "View the history of a Concept.")
-	@RequestMapping(value = "/browser/{branch}/concepts/{conceptId}/history", method = RequestMethod.GET, produces = {"application/json", "text/csv"})
+	@RequestMapping(value = "/browser/{branch}/concepts/{conceptId}/history", method = RequestMethod.GET, produces = {"application/json"})
 	public ConceptHistory viewConceptHistory(@PathVariable String branch, @PathVariable String conceptId, @RequestParam(required = false, defaultValue = "false") boolean showFutureVersions) {
 		branch = BranchPathUriUtil.decodePath(branch);
 		if (!conceptService.exists(conceptId, branch)) {


### PR DESCRIPTION
BROWSE-241 is concerned with updating Snowstorm's API to include a method for returning the history of a Concept.