### PR TITLE
MAINT-1353 - Added support for POST operation on ValueSet Expansion.

### DIFF
--- a/src/main/java/org/snomed/snowstorm/fhir/exceptions/MissingParameterException.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/exceptions/MissingParameterException.java
@@ -1,0 +1,8 @@
+package org.snomed.snowstorm.fhir.exceptions;
+
+public class MissingParameterException extends RuntimeException {
+
+	public MissingParameterException(final String message) {
+		super(message);
+	}
+}


### PR DESCRIPTION
The reason for : `@ResourceParam String rawBody` was because there isn't a nice way to encapsulate the POST body which is sent up so after doing some research, this is a work around which under a POST operation, contains the body then a simple cast can occur that maps it into the `Parameters` object. Under the GET operation, this is not used and the String content is empty so it's only ever populated at runtime when a POST operation occurs.

Currently writing unit tests.