### PR TITLE
CDI-38 - Added AttributeRange, rangeMin & rangeMax into the response for the API operation: Retrieve MRCM domain attributes applicable for the given stated parents.

### DIFF
--- a/src/main/java/org/snomed/snowstorm/mrcm/MRCMService.java
+++ b/src/main/java/org/snomed/snowstorm/mrcm/MRCMService.java
@@ -128,7 +128,7 @@ public class MRCMService {
 	private void addAttributeRangesToExtraConceptMiniFields(final ConceptMini conceptMini, final List<AttributeDomain> attributeDomains, final ContentType contentType, final MRCM branchMRCM) {
 		final List<AttributeRange> attributeRanges = new ArrayList<>();
 		branchMRCM.getAttributeRanges().forEach(attributeRange -> attributeDomains.stream()
-				.filter(attributeDomain -> attributeRange.getReferencedComponentId().equals(attributeDomain.getReferencedComponentId()) && attributeRange.getContentType() == contentType)
+				.filter(attributeDomain -> attributeRange.getReferencedComponentId().equals(attributeDomain.getReferencedComponentId()) && attributeRange.getContentType().ruleAppliesToContentType(contentType))
 				.map(attributeDomain -> attributeRange).forEach(attributeRanges::add));
 		conceptMini.addExtraField("attributeRange", attributeRanges);
 	}

--- a/src/main/java/org/snomed/snowstorm/mrcm/model/AttributeRange.java
+++ b/src/main/java/org/snomed/snowstorm/mrcm/model/AttributeRange.java
@@ -4,14 +4,16 @@ import org.snomed.snowstorm.core.data.domain.ConcreteValue;
 
 public class AttributeRange {
 
-	private String id;
-	private String effectiveTime;
-	private boolean active;
-	private String referencedComponentId;
+	private final String id;
+	private final String effectiveTime;
+	private final boolean active;
+	private final String referencedComponentId;
 	private String rangeConstraint;
+	private String rangeMin;
+	private String rangeMax;
 	private String attributeRule;
-	private RuleStrength ruleStrength;
-	private ContentType contentType;
+	private final RuleStrength ruleStrength;
+	private final ContentType contentType;
 	private ConcreteValue.DataType dataType;
 
 	public AttributeRange(String id, String effectiveTime, boolean active, String referencedComponentId, String rangeConstraint, String attributeRule,
@@ -27,26 +29,18 @@ public class AttributeRange {
 	}
 
 	public AttributeRange(AttributeRange attributeRange)  {
-		this.id = attributeRange.getId();
-		this.effectiveTime = attributeRange.getEffectiveTime();
-		this.active = attributeRange.isActive();
-		this.referencedComponentId = attributeRange.getReferencedComponentId();
-		this.rangeConstraint = attributeRange.getRangeConstraint();
-		this.attributeRule = attributeRange.getAttributeRule();
-		this.ruleStrength = attributeRange.getRuleStrength();
-		this.contentType = attributeRange.getContentType();
+		this(attributeRange.getId(), attributeRange.getEffectiveTime(), attributeRange.isActive(), attributeRange.getReferencedComponentId(),
+		attributeRange.getRangeConstraint(), attributeRange.getAttributeRule(), attributeRange.getRuleStrength(), attributeRange.getContentType());
 	}
 
 	public AttributeRange(String id, String effectiveTime, boolean active, String referencedComponentId, String rangeConstraint, String attributeRule,
 						  RuleStrength ruleStrength, ContentType contentType, ConcreteValue.DataType dataType) {
-		this.id = id;
-		this.effectiveTime = effectiveTime;
-		this.active = active;
-		this.referencedComponentId = referencedComponentId;
-		this.rangeConstraint = rangeConstraint;
-		this.attributeRule = attributeRule;
-		this.ruleStrength = ruleStrength;
-		this.contentType = contentType;
+		this(id, effectiveTime, active, referencedComponentId, rangeConstraint, attributeRule, ruleStrength, contentType);
+		if (dataType != null) {
+			final ConcreteValueRangeConstraint concreteValueRangeConstraint = new ConcreteValueRangeConstraint(rangeConstraint);
+			this.rangeMin = concreteValueRangeConstraint.getMinimumValue();
+			this.rangeMax = concreteValueRangeConstraint.getMaximumValue();
+		}
 		this.dataType = dataType;
 	}
 
@@ -69,6 +63,14 @@ public class AttributeRange {
 	}
 
 	public String getRangeConstraint() { return rangeConstraint; }
+
+	public String getRangeMin() {
+		return rangeMin;
+	}
+
+	public String getRangeMax() {
+		return rangeMax;
+	}
 
 	public String getAttributeRule() { return attributeRule; }
 

--- a/src/test/java/org/snomed/snowstorm/core/data/services/MRCMServiceTest.java
+++ b/src/test/java/org/snomed/snowstorm/core/data/services/MRCMServiceTest.java
@@ -1,24 +1,28 @@
 package org.snomed.snowstorm.core.data.services;
 
+import com.google.common.collect.Sets;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.snomed.snowstorm.AbstractTest;
 import org.snomed.snowstorm.TestConfig;
-import org.snomed.snowstorm.core.data.domain.Concept;
-import org.snomed.snowstorm.core.data.domain.ConceptMini;
-import org.snomed.snowstorm.core.data.domain.Concepts;
-import org.snomed.snowstorm.core.data.domain.Relationship;
+import org.snomed.snowstorm.core.data.domain.*;
 import org.snomed.snowstorm.mrcm.MRCMService;
+import org.snomed.snowstorm.mrcm.model.AttributeRange;
 import org.snomed.snowstorm.mrcm.model.ContentType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 import static io.kaicode.elasticvc.api.ComponentService.LARGE_PAGE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.snomed.snowstorm.core.data.domain.Concepts.ISA;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = TestConfig.class)
@@ -36,10 +40,10 @@ class MRCMServiceTest extends AbstractTest {
 	@BeforeEach
 	void setup() throws ServiceException {
 		conceptService.create(new Concept(Concepts.SNOMEDCT_ROOT).addFSN("SNOMED CT"), "MAIN");
-		conceptService.create(new Concept(Concepts.ISA).addFSN("Term").addRelationship(new Relationship(Concepts.ISA, Concepts.SNOMEDCT_ROOT).setInferred(true)), "MAIN");
+		conceptService.create(new Concept(ISA).addFSN("Term").addRelationship(new Relationship(ISA, Concepts.SNOMEDCT_ROOT).setInferred(true)), "MAIN");
 		boolean stated = false;
 		assertEquals(2, queryService.eclSearch("*", stated, "MAIN", LARGE_PAGE).getTotalElements());
-		assertEquals(1, queryService.eclSearch(Concepts.ISA, stated, "MAIN", LARGE_PAGE).getTotalElements());
+		assertEquals(1, queryService.eclSearch(ISA, stated, "MAIN", LARGE_PAGE).getTotalElements());
 	}
 
 	@Test
@@ -47,13 +51,37 @@ class MRCMServiceTest extends AbstractTest {
 		// When no parents are supplied, Is a (attribute) should be returned.
 		Collection<ConceptMini> attributes = mrcmService.retrieveDomainAttributes(ContentType.NEW_PRECOORDINATED, true, null, "MAIN", null);
 		assertEquals(1, attributes.size());
-		assertEquals(Concepts.ISA, attributes.iterator().next().getId());
+		assertEquals(ISA, attributes.iterator().next().getId());
 	}
 
 	@Test
 	void testRetrieveAttributeValue() throws ServiceException {
-		Collection<ConceptMini> result = mrcmService.retrieveAttributeValues(ContentType.NEW_PRECOORDINATED, Concepts.ISA, Concepts.ISA, "MAIN", null);
+		Collection<ConceptMini> result = mrcmService.retrieveAttributeValues(ContentType.NEW_PRECOORDINATED, ISA, ISA, "MAIN", null);
 		assertEquals(1, result.size());
-		assertEquals(Concepts.ISA, result.iterator().next().getConceptId());
+		assertEquals(ISA, result.iterator().next().getConceptId());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void testExtraConceptMiniFields() throws ServiceException {
+		final Concept inConcept = new Concept("12345678910");
+		inConcept.addAxiom(new Relationship(ISA, "12345"), Relationship.newConcrete(ISA, ConcreteValue.newInteger("#1")));
+		createRangeConstraint(ISA, "dec(>#0..)");
+		conceptService.create(inConcept, MAIN);
+
+		Collection<ConceptMini> attributes = mrcmService.retrieveDomainAttributes(ContentType.ALL, true,
+				Sets.newHashSet(12345678910L), MAIN, null);
+		assertNotNull(attributes);
+		attributes.forEach(attribute -> {
+			final Map<String, Object> extraFields = attribute.getExtraFields();
+			final List<AttributeRange> attributeRanges = (List<AttributeRange>) extraFields.get("attributeRange");
+			assertFalse(attributeRanges.isEmpty());
+			final AttributeRange attributeRange = attributeRanges.get(0);
+			assertEquals(ContentType.ALL, attributeRange.getContentType());
+			assertEquals(">#0", attributeRange.getRangeMin());
+			assertEquals("", attributeRange.getRangeMax());
+			assertEquals(ISA, attributeRange.getReferencedComponentId());
+			assertEquals(ConcreteValue.DataType.DECIMAL, attributeRange.getDataType());
+		});
 	}
 }


### PR DESCRIPTION
Example Response (which shows attributeRange, rangeMin & rangeMax being returned (if applicable)):

```"attributeRange": [
        {
          "id": "17eec929-cccc-4713-a71d-4d9f422117c5",
          "active": true,
          "referencedComponentId": "1142135004",
          "rangeConstraint": "dec(>#0..)",
          "rangeMin": ">#0",
          "rangeMax": "",
          "attributeRule": "<< 373873005 |Pharmaceutical / biologic product (product)|: [0..*] { [0..1] 1142135004 |Has presentation strength numerator value| > #0 }",
          "ruleStrength": "MANDATORY",
          "contentType": "ALL",
          "dataType": "DECIMAL"
        }...

I addressed what we spoke about before:

"we should keep the list of AttributeRanges separate in the response and just filter the list based on the AttributeDomains and content type that has been selected."