### PR TITLE
MAINT-1462 - Refactored the code to insert the validation results into the body of the Concept when ERRORS/WARNINGS are found after validation has been performed and moved the Spring validation around so that it performs the validation after the creation/update operation has been performed when the validate flag has been set to true. If it's set to false, it will simply perform the validation first (as normal) then proceed with the underlying operation.

### DIFF
--- a/src/main/java/org/snomed/snowstorm/config/SecurityAndUriConfig.java
+++ b/src/main/java/org/snomed/snowstorm/config/SecurityAndUriConfig.java
@@ -3,16 +3,14 @@ package org.snomed.snowstorm.config;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.google.common.collect.Lists;
 import io.kaicode.elasticvc.domain.Branch;
 import io.kaicode.rest.util.branchpathrewrite.BranchPathUriRewriteFilter;
+import org.ihtsdo.drools.domain.Component;
+import org.ihtsdo.drools.response.InvalidContent;
 import org.ihtsdo.sso.integration.RequestHeaderAuthenticationDecorator;
 import org.snomed.snowstorm.core.data.domain.CodeSystemVersion;
 import org.snomed.snowstorm.core.data.domain.classification.Classification;
-import org.snomed.snowstorm.rest.config.BranchMixIn;
-import org.snomed.snowstorm.rest.config.ClassificationMixIn;
-import org.snomed.snowstorm.rest.config.CodeSystemVersionMixIn;
-import org.snomed.snowstorm.rest.config.PageMixin;
+import org.snomed.snowstorm.rest.config.*;
 import org.snomed.snowstorm.rest.pojo.BranchPojo;
 import org.snomed.snowstorm.rest.security.RequestHeaderAuthenticationDecoratorWithRequiredRole;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,7 +75,9 @@ public class SecurityAndUriConfig extends WebSecurityConfigurerAdapter {
 				.mixIn(Branch.class, BranchMixIn.class)
 				.mixIn(BranchPojo.class, BranchMixIn.class)
 				.mixIn(Classification.class, ClassificationMixIn.class)
-				.mixIn(CodeSystemVersion.class, CodeSystemVersionMixIn.class);
+				.mixIn(CodeSystemVersion.class, CodeSystemVersionMixIn.class)
+				.mixIn(InvalidContent.class, InvalidContentMixIn.class)
+				.mixIn(Component.class, ComponentMixIn.class);
 
 		if (jsonIndentOutput) {
 			builder.featuresToEnable(SerializationFeature.INDENT_OUTPUT);

--- a/src/main/java/org/snomed/snowstorm/core/data/domain/Concept.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/domain/Concept.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.google.common.collect.Sets;
+import org.ihtsdo.drools.response.InvalidContent;
 import org.snomed.snowstorm.core.pojo.LanguageDialect;
 import org.snomed.snowstorm.core.pojo.TermLangPojo;
 import org.snomed.snowstorm.core.util.DescriptionHelper;
@@ -23,7 +24,7 @@ import static org.snomed.snowstorm.config.Config.DEFAULT_LANGUAGE_DIALECTS;
 
 @Document(indexName = "concept")
 @JsonPropertyOrder({"conceptId", "descendantCount", "fsn", "pt", "active", "effectiveTime", "released", "releasedEffectiveTime",  "inactivationIndicator", "associationTargets",
-		"moduleId", "definitionStatus", "definitionStatusId", "descriptions", "classAxioms", "gciAxioms", "relationships"})
+		"moduleId", "definitionStatus", "definitionStatusId", "descriptions", "classAxioms", "gciAxioms", "relationships", "validationResults"})
 public class Concept extends SnomedComponent<Concept> implements ConceptView, SnomedComponentWithInactivationIndicator, SnomedComponentWithAssociations {
 
 	public interface Fields extends SnomedComponent.Fields {
@@ -80,6 +81,9 @@ public class Concept extends SnomedComponent<Concept> implements ConceptView, Sn
 	@Transient
 	private Long descendantCount;
 
+	@Transient
+	private List<InvalidContent> validationResults;
+
 	public Concept() {
 		active = true;
 		setModuleId(Concepts.CORE_MODULE);
@@ -89,6 +93,7 @@ public class Concept extends SnomedComponent<Concept> implements ConceptView, Sn
 		classAxioms = new HashSet<>();
 		generalConceptInclusionAxioms = new HashSet<>();
 		inactivationIndicatorMembers = new ArrayList<>();
+		validationResults = new ArrayList<>();
 	}
 
 	public Concept(String conceptId) {
@@ -398,6 +403,16 @@ public class Concept extends SnomedComponent<Concept> implements ConceptView, Sn
 
 	public void setRequestedLanguageDialects(List<LanguageDialect> requestedLanguageDialects) {
 		this.requestedLanguageDialects = requestedLanguageDialects;
+	}
+
+	@JsonView(value = View.Component.class)
+	@Override
+	public List<InvalidContent> getValidationResults() {
+		return validationResults;
+	}
+
+	public void setValidationResults(final List<InvalidContent> validationResults) {
+		this.validationResults = validationResults;
 	}
 
 	@Override

--- a/src/main/java/org/snomed/snowstorm/core/data/domain/ConceptView.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/domain/ConceptView.java
@@ -1,8 +1,10 @@
 package org.snomed.snowstorm.core.data.domain;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.ihtsdo.drools.response.InvalidContent;
 import org.snomed.snowstorm.core.pojo.TermLangPojo;
 
+import java.util.List;
 import java.util.Set;
 
 @JsonDeserialize(as = Concept.class)
@@ -30,4 +32,6 @@ public interface ConceptView {
 	Set<Axiom> getClassAxioms();
 
 	Set<Axiom> getGciAxioms();
+
+	List<InvalidContent> getValidationResults();
 }

--- a/src/main/java/org/snomed/snowstorm/rest/ConceptController.java
+++ b/src/main/java/org/snomed/snowstorm/rest/ConceptController.java
@@ -94,7 +94,7 @@ public class ConceptController {
 	private ObjectMapper objectMapper;
 
 	@Autowired
-	private Validator validator;
+	private Validator beanInstanceValidator;
 
 	@Value("${snowstorm.rest-api.allowUnlimitedConceptPagination:false}")
 	private boolean allowUnlimitedConceptPagination;
@@ -400,7 +400,7 @@ public class ConceptController {
 				final Concept createdConcept = conceptService.create((Concept) concept, ControllerHelper.parseAcceptLanguageHeaderWithDefaultFallback(acceptLanguageHeader),
 						BranchPathUriUtil.decodePath(branch));
 				// validate concept after creation due to temporary id provided by UI can exceed the concept id range.
-				validator.validate(createdConcept);
+				beanInstanceValidator.validate(createdConcept);
 				createdConcept.setValidationResults(ConceptValidationHelper.replaceTemporaryUUIDWithSCTID(invalidContent.getInvalidContents(), createdConcept));
 				return new ResponseEntity<>(createdConcept, ControllerHelper.getCreatedLocationHeaders(createdConcept.getId()), HttpStatus.OK);
 			}
@@ -408,7 +408,7 @@ public class ConceptController {
 			return new ResponseEntity<>(concept, HttpStatus.BAD_REQUEST);
 		}
 
-		validator.validate(concept);
+		beanInstanceValidator.validate(concept);
 		final Concept createdConcept = conceptService.create((Concept) concept, ControllerHelper.parseAcceptLanguageHeaderWithDefaultFallback(acceptLanguageHeader),
 				BranchPathUriUtil.decodePath(branch));
 		return new ResponseEntity<>(createdConcept, getCreatedLocationHeaders(createdConcept.getId()), HttpStatus.OK);
@@ -433,7 +433,7 @@ public class ConceptController {
 				final Concept updatedConcept = conceptService.update((Concept) concept, ControllerHelper.parseAcceptLanguageHeaderWithDefaultFallback(acceptLanguageHeader),
 						BranchPathUriUtil.decodePath(branch));
 				// validate concept after creation due to temporary id provided by UI can exceed the concept id range.
-				validator.validate(updatedConcept);
+				beanInstanceValidator.validate(updatedConcept);
 				updatedConcept.setValidationResults(ConceptValidationHelper.replaceTemporaryUUIDWithSCTID(invalidContent.getInvalidContents(), updatedConcept));
 				return new ResponseEntity<>(updatedConcept, HttpStatus.OK);
 			}
@@ -441,7 +441,7 @@ public class ConceptController {
 			return new ResponseEntity<>(concept, HttpStatus.BAD_REQUEST);
 		}
 
-		validator.validate(concept);
+		beanInstanceValidator.validate(concept);
 		return new ResponseEntity<>(conceptService.update((Concept) concept, ControllerHelper.parseAcceptLanguageHeaderWithDefaultFallback(acceptLanguageHeader),
 				BranchPathUriUtil.decodePath(branch)), HttpStatus.OK);
 	}

--- a/src/main/java/org/snomed/snowstorm/rest/config/ComponentMixIn.java
+++ b/src/main/java/org/snomed/snowstorm/rest/config/ComponentMixIn.java
@@ -1,0 +1,22 @@
+package org.snomed.snowstorm.rest.config;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import org.snomed.snowstorm.rest.View;
+
+public interface ComponentMixIn {
+
+	@JsonView(value = View.Component.class)
+	String getId();
+
+	@JsonView(value = View.Component.class)
+	boolean isActive();
+
+	@JsonView(value = View.Component.class)
+	boolean isPublished();
+
+	@JsonView(value = View.Component.class)
+	boolean isReleased();
+
+	@JsonView(value = View.Component.class)
+	String getModuleId();
+}

--- a/src/main/java/org/snomed/snowstorm/rest/config/InvalidContentMixIn.java
+++ b/src/main/java/org/snomed/snowstorm/rest/config/InvalidContentMixIn.java
@@ -1,0 +1,36 @@
+package org.snomed.snowstorm.rest.config;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import org.ihtsdo.drools.domain.Component;
+import org.ihtsdo.drools.response.Severity;
+import org.snomed.snowstorm.rest.View;
+
+public interface InvalidContentMixIn {
+
+	@JsonView(value = View.Component.class)
+	void ignorePublishedCheck();
+
+	@JsonView(value = View.Component.class)
+	String getConceptId();
+
+	@JsonView(value = View.Component.class)
+	String getComponentId();
+
+	@JsonView(value = View.Component.class)
+	boolean isIgnorePublishedCheck();
+
+	@JsonView(value = View.Component.class)
+	boolean isPublished();
+
+	@JsonView(value = View.Component.class)
+	String getMessage();
+
+	@JsonView(value = View.Component.class)
+	Severity getSeverity();
+
+	@JsonView(value = View.Component.class)
+	Component getComponent();
+
+	@JsonView(value = View.Component.class)
+	String getConceptFsn();
+}

--- a/src/main/java/org/snomed/snowstorm/rest/config/RestControllerAdvice.java
+++ b/src/main/java/org/snomed/snowstorm/rest/config/RestControllerAdvice.java
@@ -7,7 +7,6 @@ import org.slf4j.LoggerFactory;
 import org.snomed.langauges.ecl.ECLException;
 import org.snomed.snowstorm.core.data.services.NotFoundException;
 import org.snomed.snowstorm.core.data.services.TooCostlyException;
-import org.snomed.snowstorm.validation.exception.DroolsValidationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
@@ -36,21 +35,16 @@ public class RestControllerAdvice {
 			MethodArgumentNotValidException.class,
 			MethodArgumentTypeMismatchException.class,
 			MissingServletRequestParameterException.class,
-			ECLException.class,
-			DroolsValidationException.class
+			ECLException.class
 	})
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ResponseBody
 	public Map<String, Object> handleIllegalArgumentException(Exception exception) {
 		HashMap<String, Object> result = new HashMap<>();
 		result.put("error", HttpStatus.BAD_REQUEST);
-		if (exception instanceof DroolsValidationException) {
-			result.put("validation-results", exception.getMessage().replace("\n", ""));
-		} else {
-			result.put("message", exception.getMessage());
-			if (exception.getCause() != null) {
-				result.put("causeMessage", exception.getCause().getMessage());
-			}
+		result.put("message", exception.getMessage());
+		if (exception.getCause() != null) {
+			result.put("causeMessage", exception.getCause().getMessage());
 		}
 		logger.info("bad request {}", exception.getMessage());
 		logger.debug("bad request {}", exception.getMessage(), exception);

--- a/src/main/java/org/snomed/snowstorm/validation/ConceptValidationHelper.java
+++ b/src/main/java/org/snomed/snowstorm/validation/ConceptValidationHelper.java
@@ -21,9 +21,8 @@ public final class ConceptValidationHelper {
 	public static InvalidContentWithSeverityStatus validate(final Concept concept, final String branchPath, final DroolsValidationService validationService) throws ServiceException {
 		final List<InvalidContent> invalidContents = validationService.validateConcept(branchPath, generateUUIDSIfNotSet(concept));
 		final List<InvalidContent> invalidContentErrors = invalidContents.stream().filter(invalidContent -> invalidContent.getSeverity() == Severity.ERROR).collect(Collectors.toList());
-		return invalidContentErrors.isEmpty() ? new InvalidContentWithSeverityStatus(invalidContents.stream().filter(invalidContent ->
-				invalidContent.getSeverity() == Severity.WARNING).collect(Collectors.toList()), Severity.WARNING)
-				: new InvalidContentWithSeverityStatus(invalidContents, Severity.ERROR);
+		return invalidContentErrors.isEmpty() ? new InvalidContentWithSeverityStatus(invalidContents, Severity.WARNING) :
+				new InvalidContentWithSeverityStatus(invalidContents, Severity.ERROR);
 	}
 
 	private static Concept generateUUIDSIfNotSet(final Concept concept) {

--- a/src/main/java/org/snomed/snowstorm/validation/exception/DroolsValidationException.java
+++ b/src/main/java/org/snomed/snowstorm/validation/exception/DroolsValidationException.java
@@ -1,8 +1,0 @@
-package org.snomed.snowstorm.validation.exception;
-
-public class DroolsValidationException extends RuntimeException {
-
-	public DroolsValidationException(final String message) {
-		super(message);
-	}
-}

--- a/src/test/java/org/snomed/snowstorm/rest/ConceptSerialisationTest.java
+++ b/src/test/java/org/snomed/snowstorm/rest/ConceptSerialisationTest.java
@@ -3,17 +3,20 @@ package org.snomed.snowstorm.rest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import org.ihtsdo.drools.response.InvalidContent;
+import org.ihtsdo.drools.response.Severity;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.snomed.snowstorm.core.data.domain.*;
 import org.snomed.snowstorm.core.data.repositories.config.ConceptStoreMixIn;
 import org.snomed.snowstorm.core.data.repositories.config.DescriptionStoreMixIn;
 import org.snomed.snowstorm.core.data.repositories.config.RelationshipStoreMixIn;
+import org.snomed.snowstorm.validation.domain.DroolsConcept;
 
 import java.io.IOException;
+import java.util.Collections;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 class ConceptSerialisationTest {
 
@@ -73,6 +76,26 @@ class ConceptSerialisationTest {
 		assertTrue(conceptJson.contains("relationships"));
 		assertTrue(conceptJson.contains("classAxioms"));
 		assertTrue(conceptJson.contains("gciAxioms"));
+	}
+
+	@Test
+	void testCreateConceptFailsAfterValidationSerialisation() throws JsonProcessingException {
+		final Concept concept = new Concept("123", null, true, "33", "900000000000074008");
+		final InvalidContent invalidContent = new InvalidContent("123", new DroolsConcept(concept), "This is a test to see the serialised content", Severity.ERROR);
+		concept.setValidationResults(Collections.singletonList(invalidContent));
+		final String conceptJson = generalObjectMapper.writerWithView(View.Component.class).forType(ConceptView.class).writeValueAsString(concept);
+		assertNotNull(conceptJson);
+		assertTrue(conceptJson.contains("conceptId"));
+		assertTrue(conceptJson.contains("component"));
+		assertTrue(conceptJson.contains("published"));
+		assertTrue(conceptJson.contains("active"));
+		assertTrue(conceptJson.contains("moduleId"));
+		assertTrue(conceptJson.contains("released"));
+		assertTrue(conceptJson.contains("id"));
+		assertTrue(conceptJson.contains("message"));
+		assertTrue(conceptJson.contains("severity"));
+		assertTrue(conceptJson.contains("ignorePublishedCheck"));
+		assertTrue(conceptJson.contains("published"));
 	}
 
 	@Test


### PR DESCRIPTION
Example Response of the validation results as part of the Concept object returned which contains ERRORS/WARNINGS:
![image](https://user-images.githubusercontent.com/74201527/108062396-a6523780-7051-11eb-8ef0-d7de68cbe3f8.png)
