### PR TITLE
MAINT-1323 Fix concepts losing release details

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/domain/SnomedComponent.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/domain/SnomedComponent.java
@@ -80,6 +80,21 @@ public abstract class SnomedComponent<C> extends DomainEntity<C> implements IdAn
 		setReleaseHash(component.getReleaseHash());
 		setReleasedEffectiveTime(component.getReleasedEffectiveTime());
 	}
+	
+	public void copyReleaseDetails(SnomedComponent<C> component, SnomedComponent<C> existingRebaseSourceComponent) {
+		//Are we copying the released details from the existing component, or has the rebase source been versioned more recently?
+		SnomedComponent<C> mostRecentlyPublished = component;
+		if (existingRebaseSourceComponent != null && existingRebaseSourceComponent.isReleased() &&
+			(!component.isReleased() || 
+				existingRebaseSourceComponent.getReleasedEffectiveTime() > component.getReleasedEffectiveTime())) {
+			mostRecentlyPublished = existingRebaseSourceComponent;
+		}
+		
+		setEffectiveTimeI(mostRecentlyPublished.getEffectiveTimeI());
+		setReleased(mostRecentlyPublished.isReleased());
+		setReleaseHash(mostRecentlyPublished.getReleaseHash());
+		setReleasedEffectiveTime(mostRecentlyPublished.getReleasedEffectiveTime());
+	}
 
 	public void clearReleaseDetails() {
 		setEffectiveTimeI(null);

--- a/src/main/java/org/snomed/snowstorm/core/data/services/BranchMergeService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/BranchMergeService.java
@@ -192,8 +192,8 @@ public class BranchMergeService {
 			// This just locks the target branch.
 			// Content will be taken from the latest complete commit on the source branch.
 			try (Commit commit = branchService.openRebaseCommit(targetBranch.getPath(), branchMetadataHelper.getBranchLockMetadata("Rebasing changes from " + source))) {
+				commit.setSourceBranchPath(source);
 				if (manuallyMergedConcepts != null && !manuallyMergedConcepts.isEmpty()) {
-
 					Set<String> conceptsToDelete = manuallyMergedConcepts.stream()
 							.filter(Concept::isDeleted).map(Concept::getConceptId).collect(Collectors.toSet());
 					if (!conceptsToDelete.isEmpty()) {

--- a/src/main/java/org/snomed/snowstorm/core/data/services/ConceptService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/ConceptService.java
@@ -747,7 +747,7 @@ public class ConceptService extends ComponentService {
 		Map<String, Concept> existingSourceConceptsMap = new HashMap<>();
 		final List<String> conceptIds = concepts.stream().filter(concept -> concept.getConceptId() != null).map(Concept::getConceptId).collect(Collectors.toList());
 		if (!conceptIds.isEmpty()) {
-			BranchTimepoint branchTimePoint = new BranchTimepoint(commit.getSourceBranchPath(), BranchTimepoint.DATE_FORMAT.format(commit.getTimepoint()));
+			BranchTimepoint branchTimePoint = new BranchTimepoint(commit.getSourceBranchPath(), BranchTimepoint.DATE_FORMAT.format(commit.getBranch().getBase()));
 			for (List<String> conceptIdPartition : Iterables.partition(conceptIds, 500)) {
 				final List<Concept> existingConcepts = doFind(conceptIdPartition, DEFAULT_LANGUAGE_DIALECTS, branchTimePoint, PageRequest.of(0, conceptIds.size())).getContent();
 				for (Concept existingConcept : existingConcepts) {

--- a/src/main/java/org/snomed/snowstorm/core/data/services/ReferenceSetMemberService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/ReferenceSetMemberService.java
@@ -370,6 +370,7 @@ public class ReferenceSetMemberService extends ComponentService {
 		return elasticsearchTemplate.search(query, ReferenceSetType.class).stream().map(SearchHit::getContent).collect(Collectors.toList());
 	}
 
+	//TODO If this could be called during a rebase, include the source branch and pass existingRebaseSourceMember into copyReleaseDetails
 	public ReferenceSetMember updateMember(String branch, ReferenceSetMember member) {
 
 		ReferenceSetMember existingMember = findMember(branch, member.getMemberId());

--- a/src/test/java/org/snomed/snowstorm/commitexplorer/CommitExplorer.java
+++ b/src/test/java/org/snomed/snowstorm/commitexplorer/CommitExplorer.java
@@ -1,22 +1,13 @@
 package org.snomed.snowstorm.commitexplorer;
 
 import io.kaicode.elasticvc.domain.Branch;
-import org.apache.http.HttpHost;
-import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
-import org.snomed.snowstorm.TestConfig;
 import org.snomed.snowstorm.config.ElasticsearchConfig;
-import org.snomed.snowstorm.config.elasticsearch.DateToLongConverter;
-import org.snomed.snowstorm.config.elasticsearch.IndexConfig;
-import org.snomed.snowstorm.config.elasticsearch.LongToDateConverter;
-import org.snomed.snowstorm.config.elasticsearch.SnowstormElasticsearchMappingContext;
 import org.snomed.snowstorm.core.data.domain.Concept;
 import org.snomed.snowstorm.core.data.domain.Description;
 import org.snomed.snowstorm.core.data.domain.ReferenceSetMember;
 import org.snomed.snowstorm.core.data.domain.SnomedComponent;
-import org.snomed.snowstorm.core.data.services.DomainEntityConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration;
@@ -24,18 +15,12 @@ import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestCli
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
-import org.springframework.data.elasticsearch.core.convert.ElasticsearchCustomConversions;
-import org.springframework.data.elasticsearch.core.convert.MappingElasticsearchConverter;
-import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
 import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
-
-import java.util.Arrays;
 
 import static java.lang.String.format;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
@@ -50,10 +35,11 @@ public class CommitExplorer {
 	private final String indexNamePrefix;
 
 	private void run() {
-		listCommits("MAIN");
-		listRecentVersions("255083005", Concept.class);
-		listRecentVersions("646067016", Description.class);
-		listRecentVersions("04591202-b9cb-45a5-8533-aa1f9e0f8644", ReferenceSetMember.class);
+		//listCommits("MAIN");
+		//listRecentVersions("209889006", Concept.class);
+		listRecentVersions("890431008", Concept.class);
+		//listRecentVersions("646067016", Description.class);
+		//listRecentVersions("84fd3311-705d-4ab0-ab84-989eaa048839", ReferenceSetMember.class);
 	}
 
 	public static void main(String[] args) {

--- a/src/test/java/org/snomed/snowstorm/core/data/services/BranchMergeServiceTest.java
+++ b/src/test/java/org/snomed/snowstorm/core/data/services/BranchMergeServiceTest.java
@@ -1033,9 +1033,15 @@ class BranchMergeServiceTest extends AbstractTest {
 		branchMergeService.mergeBranchSync("MAIN/A", "MAIN/A/A2", Collections.singleton(conceptFromRight));
 
 		Concept rebasedConcept = conceptService.find(conceptId, "MAIN/A/A2");
-		//And here we suspect that our concept is showing as newly inactive
 		assertEquals(effectiveTime, rebasedConcept.getEffectiveTime());
 		assertTrue(rebasedConcept.isReleased());
+		
+		//The description should also pick up the same time
+		Description rebasedDescription = rebasedConcept.getDescriptions().iterator().next();
+		assertEquals(effectiveTime, rebasedDescription.getEffectiveTime());
+		assertTrue(rebasedDescription.isReleased());
+		
+		//TODO Check Relationships and other associated components are also versioned as expected
 	}
 
 	@Test


### PR DESCRIPTION
Scenario for MAINT-1323 is that a concept is versioned on MAIN and also edited on some task.   The versioned concept is rebased to the project and the task is promoted, causing a merge conflict.    The user selects the right hand side and, during the merge, the "existing" concept that is used to copy the "release details" is taken from the task branch.  The details relating to versioning are then lost.     This code fix additionally collects the existing concepts from the _source_ branch (in this case the project) and pulls the release details from there **if** a concept has been released when the task version of the concept has not been.