### PR TITLE
Maint 1346

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/domain/CodeSystemVersion.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/domain/CodeSystemVersion.java
@@ -31,6 +31,9 @@ public class CodeSystemVersion {
 	@Field(type = FieldType.Keyword)
 	private String description;
 
+	@Field(type = FieldType.Keyword)
+	private String releasePackage;
+
 	public CodeSystemVersion() {
 	}
 
@@ -101,5 +104,13 @@ public class CodeSystemVersion {
 
 	public void setDescription(String description) {
 		this.description = description;
+	}
+
+	public String getReleasePackage() {
+		return releasePackage;
+	}
+
+	public void setReleasePackage(String releasePackage) {
+		this.releasePackage = releasePackage;
 	}
 }

--- a/src/main/java/org/snomed/snowstorm/core/data/services/BranchMetadataKeys.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/BranchMetadataKeys.java
@@ -8,4 +8,5 @@ public interface BranchMetadataKeys {
 	String DEFAULT_MODULE_ID = "defaultModuleId";
 	String DEFAULT_NAMESPACE = "defaultNamespace";
 	String SHORTNAME = "shortname";
+	String DEPENDENCY_RELEASE = "dependencyRelease";
 }

--- a/src/main/java/org/snomed/snowstorm/core/data/services/CodeSystemService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/CodeSystemService.java
@@ -230,14 +230,16 @@ public class CodeSystemService {
 	}
 
 	@PreAuthorize("hasPermission('ADMIN', #codeSystemVersion.branchPath)")
-	public synchronized CodeSystemVersion updateVersion(CodeSystemVersion codeSystemVersion, String releasePackage) {
-		if (codeSystemVersion == null) {
-			logger.warn("Aborting Code System Version updating. This version doesn't exist.");
-			throw new IllegalStateException("Aborting Code System Version update. This version doesn't exist.");
+	public synchronized CodeSystemVersion updateCodeSystemVersionPackage(CodeSystemVersion codeSystemVersion, String releasePackage) {
+		String shortName = codeSystemVersion.getShortName();
+		Integer effectiveDate = codeSystemVersion.getEffectiveDate();
+		CodeSystemVersion versionToUpdate = findVersion(shortName, effectiveDate);
+		if (versionToUpdate == null) {
+			throw new IllegalStateException(String.format("No code system version found for %s with effective date %s", shortName, effectiveDate));
 		}
-		codeSystemVersion.setReleasePackage(releasePackage);
-		versionRepository.save(codeSystemVersion);
-		return codeSystemVersion;
+		versionToUpdate.setReleasePackage(releasePackage);
+		versionRepository.save(versionToUpdate);
+		return versionToUpdate;
 	}
 
 	private String getHyphenatedVersionString(Integer effectiveDate) {

--- a/src/main/java/org/snomed/snowstorm/core/data/services/CodeSystemService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/CodeSystemService.java
@@ -229,6 +229,17 @@ public class CodeSystemService {
 		return version;
 	}
 
+	@PreAuthorize("hasPermission('ADMIN', #codeSystemVersion.branchPath)")
+	public synchronized CodeSystemVersion updateVersion(CodeSystemVersion codeSystemVersion, String releasePackage) {
+		if (codeSystemVersion == null) {
+			logger.warn("Aborting Code System Version updating. This version doesn't exist.");
+			throw new IllegalStateException("Aborting Code System Version update. This version doesn't exist.");
+		}
+		codeSystemVersion.setReleasePackage(releasePackage);
+		versionRepository.save(codeSystemVersion);
+		return codeSystemVersion;
+	}
+
 	private String getHyphenatedVersionString(Integer effectiveDate) {
 		String effectiveDateString = effectiveDate.toString();
 		return effectiveDateString.substring(0, 4) + "-" + effectiveDateString.substring(4, 6) + "-" + effectiveDateString.substring(6, 8);

--- a/src/main/java/org/snomed/snowstorm/rest/CodeSystemController.java
+++ b/src/main/java/org/snomed/snowstorm/rest/CodeSystemController.java
@@ -123,10 +123,17 @@ public class CodeSystemController {
 				)
 	@RequestMapping(value = "/{shortName}/versions/{effectiveDate}", method = RequestMethod.PUT)
 	public CodeSystemVersion updateVersion(@PathVariable String shortName, @PathVariable Integer effectiveDate, @RequestParam String releasePackage) {
+		// release package and effective date checking
 		ControllerHelper.requiredParam(releasePackage, "releasePackage");
 		if (!releasePackage.endsWith(".zip")) {
 			throw new IllegalArgumentException(String.format("The release package %s is not a zip filename.", releasePackage));
 		}
+		// simple check to make sure the effective date is matching
+		if (!releasePackage.contains(String.valueOf(effectiveDate))) {
+			throw new IllegalArgumentException(String.format("The release package %s doesn't have the same effective date as %s", releasePackage, effectiveDate));
+		}
+
+		// Check CodeSystemVersion exists or not
 		CodeSystem codeSystem = codeSystemService.find(shortName);
 		ControllerHelper.throwIfNotFound("CodeSystem", codeSystem);
 

--- a/src/main/java/org/snomed/snowstorm/rest/CodeSystemController.java
+++ b/src/main/java/org/snomed/snowstorm/rest/CodeSystemController.java
@@ -22,8 +22,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import static java.lang.Boolean.TRUE;
 
@@ -120,29 +118,21 @@ public class CodeSystemController {
 	@ApiOperation(value = "Update the release package in an existing code system version",
 			notes = "This function is used to update the release package for a given version." +
 					"The shortName is the code system short name e.g SNOMEDCT" +
-					"The version is the code system version e.g 2021-01-31" +
-					"The releasePackage is the published release package name or versioned snapshot package name exported from the Snowstorm." +
-					"For example: SnomedCT_InternationalRF2_PRODUCTION_20210131T120000Z.zip")
-	@RequestMapping(value = "/{shortName}/versions/{version}", method = RequestMethod.PUT)
-	public CodeSystemVersion updateVersion(@PathVariable String shortName, @PathVariable String version, @RequestParam String releasePackage) {
+					"The effectiveDate is the release date e.g 20210131" +
+					"The releasePackage is the release zip file package name. e.g SnomedCT_InternationalRF2_PRODUCTION_20210131T120000Z.zip"
+				)
+	@RequestMapping(value = "/{shortName}/versions/{effectiveDate}", method = RequestMethod.PUT)
+	public CodeSystemVersion updateVersion(@PathVariable String shortName, @PathVariable Integer effectiveDate, @RequestParam String releasePackage) {
 		ControllerHelper.requiredParam(releasePackage, "releasePackage");
 		if (!releasePackage.endsWith(".zip")) {
-			throw new IllegalArgumentException("The release package is not a zip filename");
+			throw new IllegalArgumentException(String.format("The release package %s is not a zip filename.", releasePackage));
 		}
 		CodeSystem codeSystem = codeSystemService.find(shortName);
 		ControllerHelper.throwIfNotFound("CodeSystem", codeSystem);
 
-		List<CodeSystemVersion> versionsFound = codeSystemService.findAllVersions(shortName, TRUE)
-				.stream().filter(v -> v.getVersion().equals(version)).collect(Collectors.toList());
-		CodeSystemVersion codeSystemVersion = null;
-		if (!versionsFound.isEmpty()) {
-			if (versionsFound.size() > 1) {
-				throw new IllegalStateException(String.format("Found multiple versions for %s", version));
-			}
-			codeSystemVersion = versionsFound.get(0);
-		}
+		CodeSystemVersion codeSystemVersion = codeSystemService.findVersion(shortName, effectiveDate);
 		ControllerHelper.throwIfNotFound("CodeSystemVersion", codeSystemVersion);
-		return codeSystemService.updateVersion(codeSystemVersion, releasePackage);
+		return codeSystemService.updateCodeSystemVersionPackage(codeSystemVersion, releasePackage);
 	}
 
 	@ApiOperation(value = "Upgrade code system to a different dependant version.",

--- a/src/test/java/org/snomed/snowstorm/core/data/services/CodeSystemServiceIntegrationTest.java
+++ b/src/test/java/org/snomed/snowstorm/core/data/services/CodeSystemServiceIntegrationTest.java
@@ -116,7 +116,7 @@ class CodeSystemServiceIntegrationTest extends AbstractTest {
 	@Test
 	// We set up content for the international edition and an extension.
 	// We inactivate an international concept then see the extension break when it's upgraded.
-	void testCodeSystemUpgradeFindBrokenRelationships() throws IOException, ReleaseImportException, ServiceException {
+		void testCodeSystemUpgradeFindBrokenRelationships() throws IOException, ReleaseImportException, ServiceException {
 		// Create international code system
 		String snomedct = "SNOMEDCT";
 		codeSystemService.createCodeSystem(new CodeSystem(snomedct, "MAIN", "International Edition", ""));
@@ -171,7 +171,7 @@ class CodeSystemServiceIntegrationTest extends AbstractTest {
 		// update with release package
 		String releasePackage = "Test_20190131_Release_Snapshot.zip";
 		CodeSystemVersion codeSystemVersion = codeSystemService.findVersion(snomedct, 20190131);
-		codeSystemVersion = codeSystemService.updateVersion(codeSystemVersion, releasePackage);
+		codeSystemVersion = codeSystemService.updateCodeSystemVersionPackage(codeSystemVersion, releasePackage);
 		assertEquals(releasePackage, codeSystemVersion.getReleasePackage());
 
 		// Upgrade the extension to the new international version


### PR DESCRIPTION
@kaicode  Please review my changes for this. I have updated the API parameters after our discussion. However I have decided to leave the metadata updating logic out for now when creating a new code system. Because Dev-ops still need to run the metadata update for other configs.