### PR TITLE
MAINT-1372 Fix Snowstorm Log error "No value specified for terms query"

### DIFF
--- a/src/main/java/org/snomed/snowstorm/rest/pojo/ConceptBulkLoadRequest.java
+++ b/src/main/java/org/snomed/snowstorm/rest/pojo/ConceptBulkLoadRequest.java
@@ -34,4 +34,10 @@ public class ConceptBulkLoadRequest {
 	public Set<String> getDescriptionIds() {
 		return descriptionIds;
 	}
+
+	@JsonSetter(value = "descriptionIds")
+	public void setDescriptionIdsSafely(Set<String> descriptionIds) {
+		descriptionIds.removeIf(Objects::isNull);
+		this.descriptionIds = descriptionIds;
+	}
 }

--- a/src/main/java/org/snomed/snowstorm/rest/pojo/ConceptBulkLoadRequest.java
+++ b/src/main/java/org/snomed/snowstorm/rest/pojo/ConceptBulkLoadRequest.java
@@ -1,11 +1,9 @@
 package org.snomed.snowstorm.rest.pojo;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonSetter;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 @JsonPropertyOrder({"conceptIds", "descriptionIds"})
 public class ConceptBulkLoadRequest {
@@ -18,8 +16,19 @@ public class ConceptBulkLoadRequest {
 		descriptionIds = new HashSet<>();
 	}
 
+	public ConceptBulkLoadRequest(List<String> conceptIds, Set<String> descriptionIds) {
+		this.conceptIds = conceptIds;
+		this.descriptionIds = descriptionIds;
+	}
+
 	public List<String> getConceptIds() {
 		return conceptIds;
+	}
+
+	@JsonSetter(value = "conceptIds")
+	public void setConceptIdsSafely(List<String> conceptIds) {
+		conceptIds.removeIf(Objects::isNull);
+		this.conceptIds = conceptIds;
 	}
 
 	public Set<String> getDescriptionIds() {

--- a/src/test/java/org/snomed/snowstorm/rest/ConceptControllerTest.java
+++ b/src/test/java/org/snomed/snowstorm/rest/ConceptControllerTest.java
@@ -36,6 +36,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
@@ -863,6 +865,21 @@ class ConceptControllerTest extends AbstractTest {
 		//given
 		List<String> conceptIds = Arrays.asList("782964007", "255314001", null, null, null, "308490002");
 		ConceptBulkLoadRequest conceptBulkLoadRequest = new ConceptBulkLoadRequest(conceptIds, Collections.emptySet());
+		RequestEntity<?> request = new RequestEntity<>(conceptBulkLoadRequest, HttpMethod.POST, new URI("http://localhost:" + port + "/browser/MAIN/concepts/bulk-load"));
+
+		//when
+		ResponseEntity<?> responseEntity = this.restTemplate.exchange(request, Collection.class);
+
+		//then
+		assertEquals(200, responseEntity.getStatusCodeValue());
+	}
+
+	@Test
+	void testBulkLoadWithNullDescriptionIdentifiers() throws URISyntaxException {
+		//given
+		List<String> conceptIds = Arrays.asList("782964007", "255314001", "308490002");
+		Set<String> descriptionIds = Stream.of("3756961018", "3756960017", null, null, "705033019", "451847013").collect(Collectors.toSet());
+		ConceptBulkLoadRequest conceptBulkLoadRequest = new ConceptBulkLoadRequest(conceptIds, descriptionIds);
 		RequestEntity<?> request = new RequestEntity<>(conceptBulkLoadRequest, HttpMethod.POST, new URI("http://localhost:" + port + "/browser/MAIN/concepts/bulk-load"));
 
 		//when

--- a/src/test/java/org/snomed/snowstorm/rest/ConceptControllerTest.java
+++ b/src/test/java/org/snomed/snowstorm/rest/ConceptControllerTest.java
@@ -16,6 +16,7 @@ import org.snomed.snowstorm.core.data.services.ServiceException;
 import org.snomed.snowstorm.core.data.services.pojo.ConceptHistory;
 import org.snomed.snowstorm.core.pojo.BranchTimepoint;
 import org.snomed.snowstorm.loadtest.ItemsPagePojo;
+import org.snomed.snowstorm.rest.pojo.ConceptBulkLoadRequest;
 import org.snomed.snowstorm.util.ConceptControllerTestConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -31,6 +32,8 @@ import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
@@ -853,6 +856,20 @@ class ConceptControllerTest extends AbstractTest {
 				assertEquals(ISA, relationship.getTypeId());
 			}
 		}));
+	}
+
+	@Test
+	void testBulkLoadWithNullConceptIdentifiers() throws URISyntaxException {
+		//given
+		List<String> conceptIds = Arrays.asList("782964007", "255314001", null, null, null, "308490002");
+		ConceptBulkLoadRequest conceptBulkLoadRequest = new ConceptBulkLoadRequest(conceptIds, Collections.emptySet());
+		RequestEntity<?> request = new RequestEntity<>(conceptBulkLoadRequest, HttpMethod.POST, new URI("http://localhost:" + port + "/browser/MAIN/concepts/bulk-load"));
+
+		//when
+		ResponseEntity<?> responseEntity = this.restTemplate.exchange(request, Collection.class);
+
+		//then
+		assertEquals(200, responseEntity.getStatusCodeValue());
 	}
 
 	protected interface Procedure {


### PR DESCRIPTION
MAINT-1372 is concerned with fixing a bug in Snowstorm where the "No value specified for terms query" message appears in the log. 

To reproduce this bug, send a POST request to the _concepts/bulk-load_ endpoint with null Concept identifiers; the request will fail. The request will fail because the queryBuilder (ConceptService, line 359) will attempt to build a query with an invalid (null) terms query. 

To fix this bug, I am ignoring all null identifiers (by deserialising with setConceptIdsSafely).