### PR TITLE
MAINT-1572 Reduce Concept save time

### DIFF
--- a/src/test/java/org/snomed/snowstorm/core/data/services/identifier/IdentifierCacheManagerTest.java
+++ b/src/test/java/org/snomed/snowstorm/core/data/services/identifier/IdentifierCacheManagerTest.java
@@ -2,6 +2,7 @@ package org.snomed.snowstorm.core.data.services.identifier;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -64,6 +65,86 @@ class IdentifierCacheManagerTest extends AbstractTest {
 		//The dummy service does know how to work with partition ids and check digits
 		Long sctid = reservedBlock.getNextId(ComponentType.Concept);
 		Assert.assertNull(IdentifierService.isValidId(sctid.toString(), ComponentType.Concept));
+	}
+
+	@Test
+	void populateIdBlock_ShouldReadFromCache_WhenRequestingConceptIdentifierWithNonInternationalNamespace() throws ServiceException {
+		//given
+		int namespace = 12345;
+		IdentifierReservedBlock identifierReservedBlock = new IdentifierReservedBlock(namespace);
+		cacheManager.checkTopUpRequired();
+		cacheManager.populateIdBlock(identifierReservedBlock, 1, namespace, "10"); //first request, no cache
+		IdentifierCache cache = cacheManager.getCache(namespace, "10");
+		int firstRunIdentifiersAvailable = cache.identifiersAvailable();
+		cacheManager.topUp(cache, 1);
+		int secondRunIdentifiersAvailableBefore = cache.identifiersAvailable();
+
+		//when
+		cacheManager.populateIdBlock(identifierReservedBlock, 1, namespace, "10"); //second request, cache
+		int secondRunIdentifiersAvailableAfter = cache.identifiersAvailable();
+
+		//then
+		Assert.assertEquals(firstRunIdentifiersAvailable, 0); //Cache is empty on first run
+		Assert.assertTrue(secondRunIdentifiersAvailableBefore > firstRunIdentifiersAvailable && secondRunIdentifiersAvailableAfter > firstRunIdentifiersAvailable); //Cache is populated
+		Assert.assertEquals(secondRunIdentifiersAvailableAfter, secondRunIdentifiersAvailableBefore - 1); //Cache has had identifier removed for this test
+	}
+
+	@Test
+	void populateIdBlock_ShouldReadFromCache_WhenRequestingDescriptionIdentifierWithNonInternationalNamespace() throws ServiceException {
+		//given
+		int namespace = 123456;
+		IdentifierReservedBlock identifierReservedBlock = new IdentifierReservedBlock(namespace);
+		cacheManager.checkTopUpRequired();
+		cacheManager.populateIdBlock(identifierReservedBlock, 1, namespace, "11"); //first request, no cache
+		IdentifierCache cache = cacheManager.getCache(namespace, "11");
+		int firstRunIdentifiersAvailable = cache.identifiersAvailable();
+		cacheManager.topUp(cache, 1);
+		int secondRunIdentifiersAvailableBefore = cache.identifiersAvailable();
+
+		//when
+		cacheManager.populateIdBlock(identifierReservedBlock, 1, namespace, "11"); //second request, cache
+		int secondRunIdentifiersAvailableAfter = cache.identifiersAvailable();
+
+		//then
+		Assert.assertEquals(firstRunIdentifiersAvailable, 0); //Cache is empty on first run
+		Assert.assertTrue(secondRunIdentifiersAvailableBefore > firstRunIdentifiersAvailable && secondRunIdentifiersAvailableAfter > firstRunIdentifiersAvailable); //Cache is populated
+		Assert.assertEquals(secondRunIdentifiersAvailableAfter, secondRunIdentifiersAvailableBefore - 1); //Cache has had identifier removed for this test
+	}
+
+	@Test
+	void populateIdBlock_ShouldReadFromCache_WhenRequestingRelationshipIdentifierWithNonInternationalNamespace() throws ServiceException {
+		//given
+		int namespace = 1234567;
+		IdentifierReservedBlock identifierReservedBlock = new IdentifierReservedBlock(namespace);
+		cacheManager.checkTopUpRequired();
+		cacheManager.populateIdBlock(identifierReservedBlock, 1, namespace, "12"); //first request, no cache
+		IdentifierCache cache = cacheManager.getCache(namespace, "12");
+		int firstRunIdentifiersAvailable = cache.identifiersAvailable();
+		cacheManager.topUp(cache, 1);
+		int secondRunIdentifiersAvailableBefore = cache.identifiersAvailable();
+
+		//when
+		cacheManager.populateIdBlock(identifierReservedBlock, 1, namespace, "12"); //second request, cache
+		int secondRunIdentifiersAvailableAfter = cache.identifiersAvailable();
+
+		//then
+		Assert.assertEquals(firstRunIdentifiersAvailable, 0); //Cache is empty on first run
+		Assert.assertTrue(secondRunIdentifiersAvailableBefore > firstRunIdentifiersAvailable && secondRunIdentifiersAvailableAfter > firstRunIdentifiersAvailable); //Cache is populated
+		Assert.assertEquals(secondRunIdentifiersAvailableAfter, secondRunIdentifiersAvailableBefore - 1); //Cache has had identifier removed for this test
+	}
+
+	@Test
+	public void populateIdBlock_ShouldThrowException_WhenRequestingIdentifierForUnsupportedPartition() {
+		//given
+		int namespace = 12345678;
+		IdentifierReservedBlock identifierReservedBlock = new IdentifierReservedBlock(namespace);
+		cacheManager.checkTopUpRequired();
+
+		//then
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			//when
+			cacheManager.populateIdBlock(identifierReservedBlock, 1, namespace, "13");
+		});
 	}
 	
 	@AfterEach


### PR DESCRIPTION
MAINT-1572 is concerned with reducing Concept save time by prefetching SCTIDs for non-International namespaces. 