### PR TITLE
MAINT-1624 Sort Relationships before responding with Concept preview

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/services/ConceptAttributeSortHelper.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/ConceptAttributeSortHelper.java
@@ -88,7 +88,7 @@ public class ConceptAttributeSortHelper {
 		domainAttributeOrderMap = sortOrderProperties.getDomainAttributeOrderMap();
 	}
 
-	void sortAttributes(Iterable<Concept> concepts) {
+	public void sortAttributes(Iterable<Concept> concepts) {
 		for (Concept concept : concepts) {
 			// Attributes sort order is specified per hierarchy.
 			// Use FSN semantic tag to allow correct attribute sorting on concepts which have not yet been classified.

--- a/src/main/java/org/snomed/snowstorm/core/data/services/classification/ClassificationService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/classification/ClassificationService.java
@@ -109,6 +109,9 @@ public class ClassificationService {
 	@Autowired
 	private VersionControlHelper versionControlHelper;
 
+	@Autowired
+	private ConceptAttributeSortHelper conceptAttributeSortHelper;
+
 	private final List<Classification> classificationsInProgress;
 
 	private Thread classificationStatusPollingThread;
@@ -482,6 +485,7 @@ public class ClassificationService {
 				relationship.setTarget(relationshipChange.getDestination());
 			}
 		}
+		conceptAttributeSortHelper.sortAttributes(Collections.singleton(concept));
 	}
 
 	public Page<RelationshipChange> getRelationshipChanges(String path, String classificationId, List<LanguageDialect> languageDialects, PageRequest pageRequest) {


### PR DESCRIPTION
MAINT-1624 is concerned with updating the Classification's before/after view such that it is the same as the editing view panel. 