### PR TITLE
MAINT-1030 FHIR: Set inactive flag by default when concept is inactive

### DIFF
--- a/src/main/java/org/snomed/snowstorm/fhir/services/HapiParametersMapper.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/HapiParametersMapper.java
@@ -1,14 +1,7 @@
 package org.snomed.snowstorm.fhir.services;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-
-import org.hl7.fhir.r4.model.CodeType;
-import org.hl7.fhir.r4.model.Coding;
-import org.hl7.fhir.r4.model.Parameters;
-import org.hl7.fhir.r4.model.StringType;
-import org.hl7.fhir.r4.model.UriType;
+import com.google.common.collect.BiMap;
+import org.hl7.fhir.r4.model.*;
 import org.snomed.snowstorm.core.data.domain.*;
 import org.snomed.snowstorm.core.data.domain.expression.Expression;
 import org.snomed.snowstorm.core.data.services.ExpressionService;
@@ -16,7 +9,9 @@ import org.snomed.snowstorm.core.pojo.LanguageDialect;
 import org.snomed.snowstorm.fhir.config.FHIRConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import com.google.common.collect.BiMap;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 public class HapiParametersMapper implements FHIRConstants {
 	
@@ -73,6 +68,7 @@ public class HapiParametersMapper implements FHIRConstants {
 		Parameters parameters = getStandardParameters();
 		parameters.addParameter("version", codeSystem.toString());
 		parameters.addParameter("display", fhirHelper.getPreferredTerm(concept, designations));
+		parameters.addParameter("active", concept.isActive());
 		addProperties(parameters, concept, properties);
 		addDesignations(parameters, concept);
 		addParents(parameters, concept);

--- a/src/main/java/org/snomed/snowstorm/fhir/services/HapiValueSetMapper.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/HapiValueSetMapper.java
@@ -1,15 +1,19 @@
 package org.snomed.snowstorm.fhir.services;
 
-import java.util.List;
-import java.util.Map;
-
-import org.hl7.fhir.r4.model.*;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.ValueSet;
 import org.hl7.fhir.r4.model.ValueSet.ConceptReferenceDesignationComponent;
 import org.hl7.fhir.r4.model.ValueSet.ValueSetExpansionComponent;
 import org.hl7.fhir.r4.model.ValueSet.ValueSetExpansionContainsComponent;
-import org.snomed.snowstorm.core.data.domain.*;
+import org.snomed.snowstorm.core.data.domain.Concept;
+import org.snomed.snowstorm.core.data.domain.ConceptMini;
+import org.snomed.snowstorm.core.data.domain.Concepts;
+import org.snomed.snowstorm.core.data.domain.Description;
 import org.snomed.snowstorm.core.pojo.LanguageDialect;
 import org.snomed.snowstorm.fhir.config.FHIRConstants;
+
+import java.util.List;
+import java.util.Map;
 
 public class HapiValueSetMapper implements FHIRConstants {
 	
@@ -45,6 +49,7 @@ public class HapiValueSetMapper implements FHIRConstants {
 					if (!designations.isEmpty() && d.hasAcceptability(Concepts.PREFERRED, designations.get(0)) &&
 							d.getTypeId().equals(Concepts.SYNONYM)) {
 						component.setDisplay(d.getTerm());
+						component.setInactive(!c.isActive());
 					}
 				}
 			}

--- a/src/test/java/org/snomed/snowstorm/fhir/services/AbstractFHIRTest.java
+++ b/src/test/java/org/snomed/snowstorm/fhir/services/AbstractFHIRTest.java
@@ -82,6 +82,7 @@ public abstract class AbstractFHIRTest {
 	private boolean rolesEnabled;
 
 	protected static final String sampleSCTID = "257751006";
+	protected static final String sampleInactiveSCTID = "60363000";
 	protected static final String sampleConcreteSCTID = "2577513006";
 	protected static final String sampleModuleId = "1234";
 	protected static final String sampleVersion = "20190731";
@@ -142,6 +143,7 @@ public abstract class AbstractFHIRTest {
 			createDummyData(x, concepts, false);
 		}
 		branchService.create(MAIN);
+		concepts.add(new Concept(sampleInactiveSCTID).setActive(false));
 		conceptService.batchCreate(concepts, MAIN);
 		
 		// Version content to fill effectiveTime fields
@@ -240,6 +242,14 @@ public abstract class AbstractFHIRTest {
 		} else {
 			return value.toString();
 		}
+	}
+
+	protected Boolean toBoolean(Type value) {
+		if (value instanceof BooleanType) {
+			return ((BooleanType) value).booleanValue();
+		}
+
+		return null;
 	}
 
 	protected void checkForError(ResponseEntity<String> response) throws FHIROperationException {

--- a/src/test/java/org/snomed/snowstorm/fhir/services/CodeSystemProviderLookupTest.java
+++ b/src/test/java/org/snomed/snowstorm/fhir/services/CodeSystemProviderLookupTest.java
@@ -1,9 +1,9 @@
 package org.snomed.snowstorm.fhir.services;
 
-import org.hl7.fhir.r4.model.*;
+import org.hl7.fhir.r4.model.Parameters;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 class CodeSystemProviderLookupTest extends AbstractFHIRTest {
 
@@ -35,6 +35,26 @@ class CodeSystemProviderLookupTest extends AbstractFHIRTest {
 		
 		String sdProperty = toString(getProperty(p, "sufficientlyDefined"));
 		assertNotNull(sdProperty);
+	}
+
+	@Test
+	void testParameterActiveWhenActive() throws FHIROperationException {
+		String url = "http://localhost:" + port + "/fhir/CodeSystem/$lookup?system=http://snomed.info/sct&code=" + sampleSCTID + "&property=normalForm&property=sufficientlyDefined&_format=json";
+		Parameters p = get(url);
+
+		Boolean active = toBoolean(getProperty(p, "active"));
+
+		assertTrue(active);
+	}
+
+	@Test
+	void testParameterActiveWhenInactive() throws FHIROperationException {
+		String url = "http://localhost:" + port + "/fhir/CodeSystem/$lookup?system=http://snomed.info/sct&code=" + sampleInactiveSCTID + "&property=normalForm&property=sufficientlyDefined&_format=json";
+		Parameters p = get(url);
+
+		Boolean active = toBoolean(getProperty(p, "active"));
+
+		assertFalse(active);
 	}
 	
 }


### PR DESCRIPTION
MAINT-1030 is concerned with updating the response for both CodeSystem $lookup and ValueSet $expand to include the Concept's active state. 