### PR TITLE
MSSP-932 Add un-end-if-all-branches-ended endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ target
 *.iml
 /data
 /release
-/application-*.properties
+/application-*.properties*
 *.log
 /resources
 *.sh

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 		Current Elasticsearch _Server_ version supported by AWS is 7.7.0
 		N.B. Remember to keep TestConfig.ELASTIC_SEARCH_SERVER_VERSION and getting-started guide updated.
 		-->
-		<elasticvc.version>3.0.4</elasticvc.version>
+		<elasticvc.version>3.0.5-SNAPSHOT</elasticvc.version>
 		<elasticsearch.version>7.7.0</elasticsearch.version>
 
 		<spring-boot.version>${project.parent.version}</spring-boot.version>

--- a/src/main/java/org/snomed/snowstorm/rest/AdminController.java
+++ b/src/main/java/org/snomed/snowstorm/rest/AdminController.java
@@ -130,6 +130,15 @@ public class AdminController {
 	public void rollbackPartialCommit(@PathVariable String branch) {
 		sBranchService.rollbackPartialCommit(BranchPathUriUtil.decodePath(branch));
 	}
+	
+	@ApiOperation(value = "Remove the 'end' field when all instances of a branch are ended.",
+			notes = "There should NEVER be a need to use this function.  It will only work when all instances of a branch are ended which eg prevents lock removal.  You must provide the end time of the branch to be un-ended as a fail-safe check."
+	)
+	@RequestMapping(value = "/{branch}/actions/un-end-if-all-branches-ended", method = RequestMethod.POST)
+	@PreAuthorize("hasPermission('ADMIN', #branch)")
+	public void unEndIfAllBranchesEnded(@PathVariable String branch,  @RequestParam long latestEndTime) {
+		sBranchService.unEndIfAllBranchesEnded(BranchPathUriUtil.decodePath(branch), latestEndTime);
+	}
 
 	@ApiOperation(value = "Hard delete a branch including its content and history.",
 			notes = "This function is not usually needed but can be used to remove a branch which needs to be recreated with the same path. " +


### PR DESCRIPTION
Solution to situation where latest branch is still locked, but also ended.

Writing this code to deal with a situation which logically should never happen so apologies for making a bad smell!

I found myself thoroughly stuck because I couldn't unlock the branch because no un-ended branch existed, and I couldn't perform a partial rollback because that process creates a new (unlocked) branch and then the rollback expects to be able to lock the previous branch, but that's still locked!  

So I've said in the Swagger notes that we should never need to use this function.

There is a dependency and matching pull request in the elasticvc project.