### PR TITLE
MAINT-1268 Show CodeSystemVersion.dependantVersionEffectiveTime when viewing CodeSystem

### DIFF
--- a/src/main/java/org/snomed/snowstorm/SnowstormApplication.java
+++ b/src/main/java/org/snomed/snowstorm/SnowstormApplication.java
@@ -4,8 +4,10 @@ import org.ihtsdo.otf.snomedboot.ReleaseImportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.snomed.snowstorm.config.Config;
+import org.snomed.snowstorm.core.data.domain.CodeSystem;
 import org.snomed.snowstorm.core.data.domain.QueryConcept;
 import org.snomed.snowstorm.core.data.services.CodeSystemService;
+import org.snomed.snowstorm.core.data.services.CodeSystemVersionService;
 import org.snomed.snowstorm.core.data.services.ReferenceSetMemberService;
 import org.snomed.snowstorm.core.data.services.StartupException;
 import org.snomed.snowstorm.core.rf2.RF2Type;
@@ -50,6 +52,9 @@ public class SnowstormApplication extends Config implements ApplicationRunner {
 	@Autowired
 	private ApplicationContext applicationContext;
 
+	@Autowired
+	private CodeSystemVersionService codeSystemVersionService;
+
 	private static final Logger logger = LoggerFactory.getLogger(SnowstormApplication.class);
 
 	public static void main(String[] args) {
@@ -83,7 +88,11 @@ public class SnowstormApplication extends Config implements ApplicationRunner {
 			logger.info("--- Snowstorm startup complete ---");
 
 			logger.info("Warming CodeSystem aggregation cache...");
-			codeSystemService.findAll();
+			List<CodeSystem> codeSystems = codeSystemService.findAll();
+
+			logger.info("Warming CodeSystemVersion dependency cache...");
+			codeSystemVersionService.initDependantVersionCache(codeSystems);
+
 			logger.info("Caches are hot.");
 
 			if (applicationArguments.containsOption(IMPORT_ARG)) {

--- a/src/main/java/org/snomed/snowstorm/core/data/domain/CodeSystemVersion.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/domain/CodeSystemVersion.java
@@ -1,5 +1,6 @@
 package org.snomed.snowstorm.core.data.domain;
 
+import org.springframework.data.annotation.Transient;
 import org.springframework.data.elasticsearch.annotations.DateFormat;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
@@ -9,6 +10,10 @@ import java.util.Date;
 
 @Document(indexName = "codesystem-version")
 public class CodeSystemVersion {
+
+	public interface Fields {
+		String VERSION = "version";
+	}
 
 	@Field(type = FieldType.Keyword)
 	private String id;
@@ -33,6 +38,9 @@ public class CodeSystemVersion {
 
 	@Field(type = FieldType.Keyword)
 	private String releasePackage;
+
+	@Transient
+	private Integer dependantVersionEffectiveTime;
 
 	public CodeSystemVersion() {
 	}
@@ -112,5 +120,28 @@ public class CodeSystemVersion {
 
 	public void setReleasePackage(String releasePackage) {
 		this.releasePackage = releasePackage;
+	}
+
+	public Integer getDependantVersionEffectiveTime() {
+		return dependantVersionEffectiveTime;
+	}
+
+	public void setDependantVersionEffectiveTime(Integer dependantVersionEffectiveTime) {
+		this.dependantVersionEffectiveTime = dependantVersionEffectiveTime;
+	}
+
+	@Override
+	public String toString() {
+		return "CodeSystemVersion{" +
+				"id='" + id + '\'' +
+				", shortName='" + shortName + '\'' +
+				", importDate=" + importDate +
+				", parentBranchPath='" + parentBranchPath + '\'' +
+				", effectiveDate=" + effectiveDate +
+				", version='" + version + '\'' +
+				", description='" + description + '\'' +
+				", releasePackage='" + releasePackage + '\'' +
+				", dependantVersionEffectiveTime=" + dependantVersionEffectiveTime +
+				'}';
 	}
 }

--- a/src/main/java/org/snomed/snowstorm/core/data/domain/CodeSystemVersion.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/domain/CodeSystemVersion.java
@@ -129,19 +129,4 @@ public class CodeSystemVersion {
 	public void setDependantVersionEffectiveTime(Integer dependantVersionEffectiveTime) {
 		this.dependantVersionEffectiveTime = dependantVersionEffectiveTime;
 	}
-
-	@Override
-	public String toString() {
-		return "CodeSystemVersion{" +
-				"id='" + id + '\'' +
-				", shortName='" + shortName + '\'' +
-				", importDate=" + importDate +
-				", parentBranchPath='" + parentBranchPath + '\'' +
-				", effectiveDate=" + effectiveDate +
-				", version='" + version + '\'' +
-				", description='" + description + '\'' +
-				", releasePackage='" + releasePackage + '\'' +
-				", dependantVersionEffectiveTime=" + dependantVersionEffectiveTime +
-				'}';
-	}
 }

--- a/src/main/java/org/snomed/snowstorm/core/data/domain/jobs/ExportConfiguration.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/domain/jobs/ExportConfiguration.java
@@ -45,6 +45,9 @@ public class ExportConfiguration {
 
 	private Set<String> moduleIds;
 
+	@ApiModelProperty(notes = "If refsetIds are included, this indicates that the export will be a refset-only export.")
+	private Set<String> refsetIds;
+
 	public ExportConfiguration() {
 	}
 
@@ -139,5 +142,13 @@ public class ExportConfiguration {
 
 	public void setModuleIds(Set<String> moduleIds) {
 		this.moduleIds = moduleIds;
+	}
+	
+	public Set<String> getRefsetIds() {
+		return refsetIds;
+	}
+
+	public void setRefsetIds(Set<String> refsetIds) {
+		this.refsetIds = refsetIds;
 	}
 }

--- a/src/main/java/org/snomed/snowstorm/core/data/services/CodeSystemService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/CodeSystemService.java
@@ -384,7 +384,7 @@ public class CodeSystemService {
 		contentInformationCache.put(branchPath, Pair.of(latestBranch.getHead(), codeSystem));
 	}
 
-	private void setDependantVersionEffectiveTime(CodeSystem codeSystem, String branchPath, Branch latestBranch) {
+	public void setDependantVersionEffectiveTime(CodeSystem codeSystem, String branchPath, Branch latestBranch) {
 		String parentPath = PathUtil.getParentPath(branchPath);
 		if (parentPath != null) {
 			CodeSystem parentCodeSystem = findByBranchPath(parentPath).orElse(null);

--- a/src/main/java/org/snomed/snowstorm/core/data/services/CodeSystemVersionService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/CodeSystemVersionService.java
@@ -1,0 +1,184 @@
+package org.snomed.snowstorm.core.data.services;
+
+import io.kaicode.elasticvc.api.BranchService;
+import io.kaicode.elasticvc.domain.Branch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.snomed.snowstorm.core.data.domain.CodeSystem;
+import org.snomed.snowstorm.core.data.domain.CodeSystemVersion;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+
+@Component
+public class CodeSystemVersionService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CodeSystemVersionService.class);
+    private static final String SNOMEDCT = "SNOMEDCT";
+
+    /*
+     * K => CodeSystemVersion.toString()
+     * V => CodeSystemVersion.getDependantVersionEffectiveTime()
+     * */
+    private final Map<String, Integer> dependantVersionCache = new HashMap<>();
+
+    @Autowired
+    private CodeSystemService codeSystemService;
+
+    @Autowired
+    private BranchService branchService;
+
+    @Autowired
+    private ElasticsearchOperations elasticsearchOperations;
+
+    /**
+     * Populate cache with the version of SCT the latest version
+     * of the CodeSystem depends on.
+     *
+     * @param codeSystems The CodeSystems to process.
+     */
+    public void initDependantVersionCache(List<CodeSystem> codeSystems) {
+        for (CodeSystem codeSystem : codeSystems) {
+            CodeSystemVersion latestVersion = codeSystem.getLatestVersion();
+            if (latestVersion == null || SNOMEDCT.equals(latestVersion.getShortName())) {
+                continue;
+            }
+            this.doGetDependantVersionForCodeSystemVersion(latestVersion)
+                .ifPresent(dependantVersion -> dependantVersionCache.putIfAbsent(latestVersion.toString(), dependantVersion));
+        }
+    }
+
+    /**
+     * Clear cache.
+     */
+    public void clearCache() {
+        LOGGER.info("Clearing cache 'dependantVersionCache'.");
+        this.dependantVersionCache.clear();
+    }
+
+    /**
+     * Get the version of SCT the CodeSystemVersion depends on.
+     *
+     * @param codeSystemVersion The CodeSystemVersion to process.
+     * @return The version of SCT the CodeSystemVersion depends on.
+     */
+    public Optional<Integer> getDependantVersionForCodeSystemVersion(CodeSystemVersion codeSystemVersion) {
+        if (codeSystemVersion == null) {
+            return Optional.empty();
+        }
+
+        String shortName = codeSystemVersion.getShortName();
+        if (SNOMEDCT.equals(shortName)) {
+            return Optional.empty();
+        }
+
+        LOGGER.debug("Looking for {}'s dependency version.", shortName);
+        String codeSystemVersionString = codeSystemVersion.toString();
+        Integer dependantVersion = dependantVersionCache.get(codeSystemVersionString);
+        if (dependantVersion == null) {
+            LOGGER.debug("CodeSystemVersion '{}' not found in cache.", codeSystemVersionString);
+            Optional<Integer> optionalDependency = this.doGetDependantVersionForCodeSystemVersion(codeSystemVersion);
+            if (optionalDependency.isEmpty()) {
+                LOGGER.debug("No dependency version found for '{}'.", codeSystemVersionString);
+                return Optional.empty();
+            }
+
+            LOGGER.debug("Adding '{}' to cache.", codeSystemVersionString);
+            dependantVersion = optionalDependency.get();
+            dependantVersionCache.put(codeSystemVersionString, dependantVersion);
+        }
+
+        return Optional.of(dependantVersion);
+    }
+
+    private Optional<Integer> doGetDependantVersionForCodeSystemVersion(CodeSystemVersion codeSystemVersion) {
+        //International has been skipped at this point.
+        String shortName = codeSystemVersion.getShortName();
+
+        /*
+         * Get the base timestamp of branch associated with CodeSystemVersion
+         * */
+        long targetBaseTimestamp = branchService.findBranchOrThrow(codeSystemVersion.getBranchPath()).getBaseTimestamp();
+
+        /*
+         * Find (grand) parent branch, where the head matches base
+         * */
+        List<Branch> targetBranches;
+        Branch targetBranch = null;
+        String targetBranchPath = codeSystemVersion.getParentBranchPath();
+        boolean hasIntermediateDependency = !targetBranchPath.equals("MAIN/" + shortName);
+        Pageable pageable = Pageable.unpaged();
+        //Edge case where CodeSystem does not directly depend on International, i.e. AR and UY
+        if (hasIntermediateDependency) {
+            targetBranches = branchService.findAllVersions(targetBranchPath, pageable).getContent();
+            for (Branch branch : targetBranches) {
+                if (targetBaseTimestamp == branch.getHeadTimestamp()) {
+                    targetBaseTimestamp = branch.getBaseTimestamp();
+                    targetBranch = branch;
+                    break;
+                }
+            }
+            if (targetBranch == null) {
+                return Optional.empty();
+            }
+        }
+
+        targetBranches = branchService.findAllVersions(targetBranchPath, pageable).getContent();
+        for (Branch branch : targetBranches) {
+            if (targetBaseTimestamp == branch.getHeadTimestamp()) {
+                targetBranch = branch;
+                break;
+            }
+        }
+        if (targetBranch == null) {
+            return Optional.empty();
+        }
+
+        /*
+         * Get CodeSystemVersion associated with release branch
+         * */
+        CodeSystem codeSystem = codeSystemService.find(shortName);
+        String path = targetBranch.getPath();
+        codeSystemService.setDependantVersionEffectiveTime(codeSystem, path, targetBranch); // Required for finding CodeSystemVersion
+        String hyphenatedVersionString = getHyphenatedVersionString(codeSystem.getDependantVersionEffectiveTime());
+        if (hyphenatedVersionString == null) {
+            return Optional.empty();
+        }
+
+        List<CodeSystemVersion> codeSystemVersions = elasticsearchOperations
+                .search(
+                        new NativeSearchQueryBuilder()
+                                .withQuery(termQuery(CodeSystemVersion.Fields.VERSION, hyphenatedVersionString))
+                                .build(),
+                        CodeSystemVersion.class
+                )
+                .get()
+                .map(SearchHit::getContent)
+                .collect(Collectors.toList());
+
+        if (!codeSystemVersions.isEmpty()) {
+            return Optional.of(codeSystemVersions.get(0).getEffectiveDate());
+        }
+
+        return Optional.empty();
+    }
+
+    private String getHyphenatedVersionString(Integer effectiveDate) {
+        if (effectiveDate == null) {
+            return null;
+        }
+
+        String effectiveDateString = effectiveDate.toString();
+        return effectiveDateString.substring(0, 4) + "-" + effectiveDateString.substring(4, 6) + "-" + effectiveDateString.substring(6, 8);
+    }
+}

--- a/src/main/java/org/snomed/snowstorm/rest/pojo/ItemsPage.java
+++ b/src/main/java/org/snomed/snowstorm/rest/pojo/ItemsPage.java
@@ -3,8 +3,8 @@ package org.snomed.snowstorm.rest.pojo;
 import com.fasterxml.jackson.annotation.JsonView;
 import org.snomed.snowstorm.core.util.SearchAfterPage;
 import org.snomed.snowstorm.rest.View;
-import org.springframework.data.domain.Page;
 import org.snomed.snowstorm.rest.converter.SearchAfterHelper;
+import org.springframework.data.domain.Page;
 import org.springframework.data.elasticsearch.core.SearchAfterPageRequest;
 
 import java.util.Collection;
@@ -17,6 +17,16 @@ public class ItemsPage<T> {
 	private final Long offset;
 	private final String searchAfter;
 	private final Object[] searchAfterArray;
+
+	//Default for Jackson (de)serialisation
+	public ItemsPage() {
+		this.items = null;
+		this.total = -1;
+		this.limit = -1;
+		this.offset = null;
+		this.searchAfter = null;
+		this.searchAfterArray = null;
+	}
 
 	public ItemsPage(Collection<T> items) {
 		this.items = items;

--- a/src/test/java/org/snomed/snowstorm/rest/CodeSystemControllerTest.java
+++ b/src/test/java/org/snomed/snowstorm/rest/CodeSystemControllerTest.java
@@ -1,0 +1,252 @@
+package org.snomed.snowstorm.rest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.snomed.snowstorm.AbstractTest;
+import org.snomed.snowstorm.TestConfig;
+import org.snomed.snowstorm.core.data.domain.CodeSystem;
+import org.snomed.snowstorm.core.data.services.CodeSystemService;
+import org.snomed.snowstorm.core.data.services.CodeSystemUpgradeService;
+import org.snomed.snowstorm.core.data.services.ServiceException;
+import org.snomed.snowstorm.rest.pojo.ItemsPage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestConfig.class)
+class CodeSystemControllerTest extends AbstractTest {
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    @Autowired
+    private CodeSystemService codeSystemService;
+
+    @Autowired
+    private CodeSystemUpgradeService codeSystemUpgradeService;
+
+    @BeforeEach
+    public void setUp() throws ServiceException {
+        givenAuthoringCycles();
+    }
+
+    @Test
+    public void listCodeSystems_ShouldReturnCodeSystems_WhenCodeSystemsExists() {
+        //given
+        String requestUrl = listCodeSystems();
+
+        //when
+        ItemsPage<?> result = this.testRestTemplate.getForObject(requestUrl, ItemsPage.class);
+
+        //then
+        assertEquals(2, result.getTotal()); //SNOMEDCT & SNOMEDCT-DM
+    }
+
+    @Test
+    public void listCodeSystems_ShouldReturnInternationalWithNoDependsOnProperty() {
+        //given
+        String requestUrl = listCodeSystems();
+
+        //when
+        ItemsPage<ItemsPage<?>> response = this.testRestTemplate.getForObject(requestUrl, ItemsPage.class);
+        Integer dependantVersionEffectiveTime = getDependantVersionEffectiveTimeFromResponse(response, 0);
+
+        //then
+        assertNull(dependantVersionEffectiveTime); //International doesn't depend on any version.
+    }
+
+    @Test
+    public void listCodeSystems_ShouldReturnCodeSystemWithExpectedProperty_WhenCodeSystemDependsOnInternational() {
+        //given
+        String requestUrl = listCodeSystems();
+
+        //when
+        ItemsPage<ItemsPage<?>> response = this.testRestTemplate.getForObject(requestUrl, ItemsPage.class);
+        Integer dependantVersionEffectiveTime = getDependantVersionEffectiveTimeFromResponse(response, 1);
+
+        //then
+        assertEquals(20200731, dependantVersionEffectiveTime); //SNOMEDCT-DM has not versioned/published 2021 yet.
+    }
+
+    @Test
+    public void findCodeSystem_ShouldReturnError_WhenCodeSystemCannotBeFound() {
+        //given
+        String requestUrl = findCodeSystem("idontexist");
+
+        //when
+        Map<String, Object> response = this.testRestTemplate.getForObject(requestUrl, Map.class);
+
+        //then
+        assertEquals("NOT_FOUND", response.get("error"));
+        assertEquals("Code System not found", response.get("message"));
+    }
+
+    @Test
+    public void findCodeSystem_ShouldReturnCodeSystems_WhenCodeSystemsExists() {
+        //given
+        String requestUrl = findCodeSystem("SNOMEDCT-DM");
+
+        //when
+        CodeSystem response = this.testRestTemplate.getForObject(requestUrl, CodeSystem.class);
+
+        //then
+        assertNotNull(response);
+        assertEquals("SNOMEDCT-DM", response.getShortName());
+    }
+
+    @Test
+    public void findCodeSystem_ShouldReturnInternationalWithNoDependsOnProperty() {
+        String requestUrl = findCodeSystem("SNOMEDCT");
+
+        //when
+        ItemsPage<ItemsPage<?>> response = this.testRestTemplate.getForObject(requestUrl, ItemsPage.class);
+        Integer dependantVersionEffectiveTime = getDependantVersionEffectiveTimeFromResponse(response, 0);
+
+        //then
+        assertNull(dependantVersionEffectiveTime); //International doesn't depend on any version.
+    }
+
+    @Test
+    public void findCodeSystem_ShouldReturnCodeSystemWithExpectedProperty_WhenCodeSystemDependsOnInternational() {
+        //given
+        String requestUrl = findCodeSystem("SNOMEDCT-DM");
+
+        //when
+        CodeSystem response = this.testRestTemplate.getForObject(requestUrl, CodeSystem.class);
+        Integer dependantVersionEffectiveTime = response.getLatestVersion().getDependantVersionEffectiveTime();
+
+        //then
+        assertEquals(20200731, dependantVersionEffectiveTime); //SNOMEDCT-DM has not versioned/published 2021 yet.
+    }
+
+    @Test
+    public void findAllVersions_ShouldReturnEmpty_WhenCodeSystemCannotBeFound() {
+        //given
+        String requestUrl = findAllVersions("idontexist");
+
+        //when
+        ItemsPage<ItemsPage<?>> response = this.testRestTemplate.getForObject(requestUrl, ItemsPage.class);
+
+        //then
+        assertEquals(0, response.getItems().size());
+    }
+
+    @Test
+    public void findAllVersions_ShouldReturnInternationalVersionsWithNoDependsOnProperty() {
+        //given
+        String requestUrl = findAllVersions("SNOMEDCT");
+
+        //when
+        ItemsPage<ItemsPage<?>> response = this.testRestTemplate.getForObject(requestUrl, ItemsPage.class);
+
+        //then
+        assertEquals(5, response.getItems().size());
+        assertNull(getDependantVersionEffectiveTimeFromResponse(response, 0));
+        assertNull(getDependantVersionEffectiveTimeFromResponse(response, 1));
+        assertNull(getDependantVersionEffectiveTimeFromResponse(response, 2));
+        assertNull(getDependantVersionEffectiveTimeFromResponse(response, 3));
+        assertNull(getDependantVersionEffectiveTimeFromResponse(response, 4));
+    }
+
+    @Test
+    public void findAllVersions_ShouldReturnExpectedDependsOnPropertyValues() {
+        //given
+        String requestUrl = findAllVersions("SNOMEDCT-DM");
+
+        //when
+        ItemsPage<ItemsPage<?>> response = this.testRestTemplate.getForObject(requestUrl, ItemsPage.class);
+
+        //then
+        assertEquals(3, response.getItems().size());
+        assertEquals(20190731, getDependantVersionEffectiveTimeFromResponse(response, 0));
+        assertEquals(20200131, getDependantVersionEffectiveTimeFromResponse(response, 1));
+        assertEquals(20200731, getDependantVersionEffectiveTimeFromResponse(response, 2));
+    }
+
+    //Wrapper for given blocks as used throughout test class
+    private void givenAuthoringCycles() throws ServiceException {
+        //given
+        //International created and versioned several times.
+        givenCodeSystemExists("SNOMEDCT", "MAIN");
+        givenCodeSystemVersionExists("SNOMEDCT", 20190131, "2019 January.");
+        givenCodeSystemVersionExists("SNOMEDCT", 20190731, "2019 July.");
+        givenCodeSystemVersionExists("SNOMEDCT", 20200131, "2020 January.");
+        givenCodeSystemVersionExists("SNOMEDCT", 20200731, "2020 July.");
+        givenCodeSystemVersionExists("SNOMEDCT", 20210131, "2021 January.");
+
+        //Test code system created in 20190131.
+        givenCodeSystemExists("SNOMEDCT-DM", "MAIN/SNOMEDCT-DM", 20190131);
+
+        //Test code system upgraded and versioned throughout 2019 & 2020.
+        givenCodeSystemUpgraded("SNOMEDCT-DM", 20190731);
+        givenCodeSystemVersionExists("SNOMEDCT-DM", 20190813, "2019 August.", 20190731);
+        givenCodeSystemUpgraded("SNOMEDCT-DM", 20200131);
+        givenCodeSystemVersionExists("SNOMEDCT-DM", 20200213, "2020 February.", 20200131);
+        givenCodeSystemUpgraded("SNOMEDCT-DM", 20200731);
+        givenCodeSystemVersionExists("SNOMEDCT-DM", 20200813, "2020 August.", 20200731);
+        givenCodeSystemUpgraded("SNOMEDCT-DM", 20210131); //Upgraded but not yet released.
+    }
+
+    private void givenCodeSystemExists(String shortName, String branchPath) {
+        codeSystemService.createCodeSystem(new CodeSystem(shortName, branchPath));
+    }
+
+    private void givenCodeSystemVersionExists(String shortName, int effectiveDate, String description) {
+        codeSystemService.createVersion(codeSystemService.find(shortName), effectiveDate, description);
+    }
+
+    private void givenCodeSystemExists(String shortName, String branchPath, Integer dependantVersion) {
+        CodeSystem newCodeSystem = new CodeSystem(shortName, branchPath);
+        newCodeSystem.setDependantVersionEffectiveTime(dependantVersion);
+        codeSystemService.createCodeSystem(newCodeSystem);
+    }
+
+    private void givenCodeSystemUpgraded(String shortName, int newDependentOnVersion) throws ServiceException {
+        codeSystemUpgradeService.upgrade(codeSystemService.find(shortName), newDependentOnVersion, false);
+    }
+
+    private void givenCodeSystemVersionExists(String shortName, int effectiveDate, String description, int dependsOn) {
+        CodeSystem codeSystem = codeSystemService.find(shortName);
+        codeSystem.setDependantVersionEffectiveTime(dependsOn);
+        codeSystemService.createVersion(codeSystem, effectiveDate, description);
+    }
+
+    private Integer getDependantVersionEffectiveTimeFromResponse(ItemsPage<ItemsPage<?>> response, int index) {
+        Collection<ItemsPage<?>> items = response.getItems();
+
+        if (items instanceof ArrayList) {
+            List<LinkedHashMap<?, ?>> itemsList = (ArrayList) items;
+            LinkedHashMap<?, ?> linkedHashMap = itemsList.get(index);
+            LinkedHashMap<?, ?> latestVersion = (LinkedHashMap) linkedHashMap.get("latestVersion");
+            if (latestVersion != null) {
+                return (Integer) latestVersion.get("dependantVersionEffectiveTime");
+            } else {
+                return (Integer) linkedHashMap.get("dependantVersionEffectiveTime");
+            }
+        }
+
+        return null;
+    }
+
+    private String listCodeSystems() {
+        return "http://localhost:" + port + "/codesystems";
+    }
+
+    private String findCodeSystem(String shortName) {
+        return "http://localhost:" + port + "/codesystems/" + shortName;
+    }
+
+    private String findAllVersions(String shortName) {
+        return "http://localhost:" + port + "/codesystems/" + shortName + "/versions";
+    }
+}


### PR DESCRIPTION
MAINT-1268 is concerned with updating the `CodeSystemController` to return an additional `dependantVersionEffectiveTime` property to indicate which specific version of SCT the `CodeSystemVersion` depends on. 