### PR TITLE
BROWSE-436 Allow whitespace in Accept-Language HTTP header

### DIFF
--- a/src/main/java/org/snomed/snowstorm/rest/ControllerHelper.java
+++ b/src/main/java/org/snomed/snowstorm/rest/ControllerHelper.java
@@ -141,6 +141,7 @@ public class ControllerHelper {
 			acceptLanguageHeader = "";
 		}
 
+		acceptLanguageHeader = acceptLanguageHeader.replaceAll("\\s+", "");
 		String[] acceptLanguageList = acceptLanguageHeader.toLowerCase().split(",");
 		for (String acceptLanguage : acceptLanguageList) {
 			if (acceptLanguage.isEmpty()) {

--- a/src/test/java/org/snomed/snowstorm/rest/ConceptControllerTest.java
+++ b/src/test/java/org/snomed/snowstorm/rest/ConceptControllerTest.java
@@ -26,6 +26,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.*;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
@@ -884,6 +885,20 @@ class ConceptControllerTest extends AbstractTest {
 
 		//when
 		ResponseEntity<?> responseEntity = this.restTemplate.exchange(request, Collection.class);
+
+		//then
+		assertEquals(200, responseEntity.getStatusCodeValue());
+	}
+
+	@Test
+	void testAcceptLanguageHeaderWithWhitespaceBetweenValues() throws URISyntaxException {
+		//given
+		MultiValueMap<String, String> headers = new HttpHeaders();
+		headers.add("Accept-Language", "en, us");
+		RequestEntity<?> request = new RequestEntity<>(headers, HttpMethod.GET, new URI("http://localhost:" + port + "/browser/MAIN/concepts/257751006"));
+
+		//when
+		ResponseEntity<?> responseEntity = this.restTemplate.exchange(request, Concept.class);
 
 		//then
 		assertEquals(200, responseEntity.getStatusCodeValue());


### PR DESCRIPTION
BROWSE-436 is concerned with updating Snowstorm to allow optional whitespace in the Accept-Language HTTP header. This was originally raised as a [GitHub Issue](https://github.com/IHTSDO/snowstorm/issues/278).