### PR TITLE
FRI-123 Update classification PAC/SAC automatically

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/services/classification/ClassificationService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/classification/ClassificationService.java
@@ -30,6 +30,7 @@ import org.snomed.snowstorm.core.data.repositories.classification.RelationshipCh
 import org.snomed.snowstorm.core.data.services.*;
 import org.snomed.snowstorm.core.data.services.classification.pojo.ClassificationStatusResponse;
 import org.snomed.snowstorm.core.data.services.classification.pojo.EquivalentConceptsResponse;
+import org.snomed.snowstorm.core.data.services.servicehook.CommitServiceHookClient;
 import org.snomed.snowstorm.core.pojo.LanguageDialect;
 import org.snomed.snowstorm.core.rf2.RF2Type;
 import org.snomed.snowstorm.core.rf2.export.ExportException;
@@ -109,6 +110,9 @@ public class ClassificationService {
 
 	@Autowired
 	private VersionControlHelper versionControlHelper;
+
+	@Autowired
+	private CommitServiceHookClient commitServiceHookClient;
 
 	@Autowired
 	private ConceptAttributeSortHelper conceptAttributeSortHelper;
@@ -242,6 +246,7 @@ public class ClassificationService {
 												final boolean classified = !inferredRelationshipChangesFound && !equivalentConceptsFound;
 												BranchClassificationStatusService.setClassificationStatus(latestBranchCommit, classified);
 												branchService.updateMetadata(latestBranchCommit.getPath(), latestBranchCommit.getMetadata());
+												mockCommitCompletion(latestBranchCommit);
 											}
 
 										} catch (IOException | ElasticsearchException e) {
@@ -737,6 +742,12 @@ public class ClassificationService {
 				equivalentConceptsRepository.saveAll(equivalentConcepts);
 			}
 		}
+	}
+
+	private void mockCommitCompletion(Branch latestBranchCommit) {
+		// AAG will act accordingly by updating criteria.
+		logger.info("Letting external system know of classification results.");
+		commitServiceHookClient.preCommitCompletion(new Commit(latestBranchCommit, Commit.CommitType.CONTENT, null, null));
 	}
 
 	public void deleteAll() {


### PR DESCRIPTION
FRI-123 is concerned with updating the PAC/SAC classification criteria on AAG whenever a commit is made. 

The majority of the functionality was written in FRI-61; this PR simply adds support for an edge case where the classification results are empty (as this does not trigger a commit). 