### PR TITLE
FRI-54 Change CommitInformation to have source & target branch paths

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/services/servicehook/CommitInformation.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/servicehook/CommitInformation.java
@@ -7,21 +7,33 @@ import java.util.Map;
 
 public class CommitInformation {
 
-	private final String path;
+	private final String sourceBranchPath;
+	private final String targetBranchPath;
 	private final Commit.CommitType commitType;
 	private final long headTime;
 	private final Map<String, Object> metadata;
 
 	public CommitInformation(Commit commit) {
 		final Branch branch = commit.getBranch();
-		path = branch.getPath();
 		commitType = commit.getCommitType();
 		headTime = commit.getBranch().getHeadTimestamp();
 		metadata = branch.getMetadata().getAsMap();
+
+		if (Commit.CommitType.CONTENT == commitType) {
+			this.sourceBranchPath = branch.getPath();
+			this.targetBranchPath = null;
+		} else {
+			this.sourceBranchPath = commit.getSourceBranchPath();
+			this.targetBranchPath = branch.getPath();
+		}
 	}
 
-	public String getPath() {
-		return path;
+	public String getSourceBranchPath() {
+		return sourceBranchPath;
+	}
+
+	public String getTargetBranchPath() {
+		return targetBranchPath;
 	}
 
 	public Commit.CommitType getCommitType() {

--- a/src/test/java/org/snomed/snowstorm/core/data/services/servicehook/CommitInformationTest.java
+++ b/src/test/java/org/snomed/snowstorm/core/data/services/servicehook/CommitInformationTest.java
@@ -1,0 +1,58 @@
+package org.snomed.snowstorm.core.data.services.servicehook;
+
+import io.kaicode.elasticvc.domain.Branch;
+import io.kaicode.elasticvc.domain.Commit;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class CommitInformationTest {
+
+	private static Commit buildCommit(String branchPath, String commitSourceBranchPath, Commit.CommitType commitType) {
+		Commit commit = new Commit(new Branch(branchPath), commitType, null, null);
+		commit.setSourceBranchPath(commitSourceBranchPath);
+		return commit;
+	}
+
+	@Test
+	void commitInformation_ShouldHaveCorrectData_WhenCommitTypeIsContent() {
+		// given
+		Commit commit = new Commit(new Branch("MAIN"), Commit.CommitType.CONTENT, null, null);
+
+		// when
+		CommitInformation commitInformation = new CommitInformation(commit);
+
+		// then
+		assertEquals("MAIN", commitInformation.getSourceBranchPath());
+		assertNull(commitInformation.getTargetBranchPath());
+	}
+
+	@Test
+	void commitInformation_ShouldHaveCorrectData_WhenCommitTypeIsRebase() {
+		// given
+		Commit commit = buildCommit("MAIN/ProjectA", "MAIN", Commit.CommitType.REBASE);
+
+		// when
+		CommitInformation commitInformation = new CommitInformation(commit);
+
+		// then
+		assertEquals(Commit.CommitType.REBASE, commitInformation.getCommitType());
+		assertEquals("MAIN", commitInformation.getSourceBranchPath());
+		assertEquals("MAIN/ProjectA", commitInformation.getTargetBranchPath());
+	}
+
+	@Test
+	void commitInformation_ShouldHaveCorrectData_WhenCommitTypeIsPromotion() {
+		// given
+		Commit commit = buildCommit("MAIN", "MAIN/ProjectA", Commit.CommitType.PROMOTION);
+
+		// when
+		CommitInformation commitInformation = new CommitInformation(commit);
+
+		// then
+		assertEquals(Commit.CommitType.PROMOTION, commitInformation.getCommitType());
+		assertEquals("MAIN/ProjectA", commitInformation.getSourceBranchPath());
+		assertEquals("MAIN", commitInformation.getTargetBranchPath());
+	}
+}


### PR DESCRIPTION
FRI-54 is concerned with either allowing or disallowing a project promotion depending on whether the appropriate criteria have been completed. The previous PR related to FRI-54 submitted was not fully tested and had a slight oversight.

Currently, when Snowstorm is promoting, the _target_ branch will be sent to AAG for criteria verification rather than the _source_ branch.