### PR TITLE
RT2-153: Multisearch return refset buckets given descriptionId parameter

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/services/DescriptionService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/DescriptionService.java
@@ -651,6 +651,8 @@ public class DescriptionService extends ComponentService {
 	void addTermClauses(String term, Collection<String> languageCodes, Collection<Long> descriptionTypes, BoolQueryBuilder boolBuilder, SearchMode searchMode) {
 		if (IdentifierService.isConceptId(term)) {
 			boolBuilder.must(termQuery(Description.Fields.CONCEPT_ID, term));
+		} else if (IdentifierService.isDescriptionId(term)) {
+			boolBuilder.must(termQuery(Description.Fields.DESCRIPTION_ID, term));
 		} else {
 			if (!Strings.isNullOrEmpty(term)) {
 				BoolQueryBuilder termFilter = new BoolQueryBuilder();


### PR DESCRIPTION
Minor change to allow multisearch/referencesets to take descriptionId as a parameter.