### PR TITLE
FRI-54 Add another property to toggle whether promotions should be blocked

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/services/servicehook/CommitServiceHookClient.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/servicehook/CommitServiceHookClient.java
@@ -24,24 +24,15 @@ public class CommitServiceHookClient implements CommitListener {
 
 	private final Logger logger = LoggerFactory.getLogger(getClass());
 	private final String serviceUrl;
-	private final boolean blockPromotion;
 
-	public CommitServiceHookClient(@Value("${service-hook.commit.url}") String serviceUrl,
-								   @Value("${service-hook.commit.block-promotion-if-error:false}") String blockPromotion) {
+	public CommitServiceHookClient(@Value("${service-hook.commit.url}") String serviceUrl) {
 		this.serviceUrl = serviceUrl;
-		this.blockPromotion = Boolean.parseBoolean(blockPromotion);
 		if (!StringUtils.isEmpty(serviceUrl)) {
 			final RestTemplateBuilder builder = new RestTemplateBuilder()
 					.rootUri(serviceUrl);
 			restTemplate = builder.build();
 		} else {
 			restTemplate = null;
-		}
-
-		if (this.blockPromotion) {
-			logger.info("Promotions will be blocked if an error is encountered.");
-		} else {
-			logger.info("Promotions will not be blocked if an error is encountered.");
 		}
 	}
 
@@ -67,16 +58,11 @@ public class CommitServiceHookClient implements CommitListener {
 					obfuscateToken(authenticationToken), e);
 			boolean promotion = commit.getCommitType().equals(Commit.CommitType.PROMOTION);
 			if (promotion && e instanceof HttpClientErrorException.Conflict) {
-				if (blockPromotion) {
-					logger.error("Promotion blocked; not all criteria have been met.");
-					throw new RuntimeServiceException("Promotion blocked; not all criteria have been met.");
-				}
+				logger.error("Promotion blocked; not all criteria have been met.");
+				throw new RuntimeServiceException("Promotion blocked; not all criteria have been met.");
 			}
 
-			if (blockPromotion) {
-				logger.error("Promotion blocked; unexpected error.");
-				throw e;
-			}
+			throw e;
 		}
 	}
 


### PR DESCRIPTION
FRI-54 is concerned with blocking promotion if the AAG indicates the associated criteria for a branch has not been completed. 

A flag has previously been added (`blockPromotion`) to toggle whether promotions should be blocked if the criteria has not been completed. This PR also adds another property (`failIfError`) to toggle whether promotions should be blocked if Snowstorm cannot communicate with AAG.