### PR TITLE
Designation use context FHIR extension implementation

### DIFF
--- a/src/main/java/org/snomed/snowstorm/fhir/services/HapiParametersMapper.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/HapiParametersMapper.java
@@ -138,6 +138,8 @@ public class HapiParametersMapper implements FHIRConstants {
 	private void addDesignations(Parameters parameters, Concept c) {
 		for (Description d : c.getActiveDescriptions()) {
 			Parameters.ParametersParameterComponent designation = parameters.addParameter().setName(DESIGNATION);
+			// TODO: add designation use context, see: src/main/java/org/snomed/snowstorm/fhir/services/HapiValueSetMapper.java
+			// private ConceptReferenceDesignationComponent asDesignation(Description d);
 			designation.addPart().setName(LANGUAGE).setValue(new CodeType(d.getLang()));
 			designation.addPart().setName(USE).setValue(new Coding(SNOMED_URI, d.getTypeId(), FHIRHelper.translateDescType(d.getTypeId())));
 			designation.addPart().setName(VALUE).setValue(new StringType(d.getTerm()));

--- a/src/main/java/org/snomed/snowstorm/fhir/services/HapiValueSetMapper.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/HapiValueSetMapper.java
@@ -77,9 +77,9 @@ public class HapiValueSetMapper implements FHIRConstants {
 			ducExt.addExtension("context", new Coding(SNOMED_URI, langRefsetId, null)); // TODO: is there a quick way to find a description for an id? Which description?
 			// Add acceptability
 			switch(acceptability) {
-			case "ACCEPTABLE":
+			case Concepts.ACCEPTABLE_CONSTANT:
 				ducExt.addExtension("role", new Coding(SNOMED_URI, Concepts.ACCEPTABLE, Concepts.ACCEPTABLE_CONSTANT));
-			case "PREFERRED":
+			case Concepts.PREFERRED_CONSTANT:
 				ducExt.addExtension("role", new Coding(SNOMED_URI, Concepts.PREFERRED, Concepts.PREFERRED_CONSTANT));
 			};
 			// Add type, this is sometimes but not always redundant to designation.use!


### PR DESCRIPTION
First attempt at implementing DUC FHIR extension: https://confluence.ihtsdotools.org/display/FHIR/Designation+extension
There are some things to discuss, e.g. how to turn this on or off or otherwise control the use of the extension.
Also, only added this for ValueSet expansion and not for CodeSystem lookup (but should be similar).