### PR TITLE
Designation use context FHIR extension implementation

### DIFF
--- a/src/main/java/org/snomed/snowstorm/fhir/services/HapiParametersMapper.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/HapiParametersMapper.java
@@ -138,12 +138,8 @@ public class HapiParametersMapper implements FHIRConstants {
 	private void addDesignations(Parameters parameters, Concept c) {
 		for (Description d : c.getActiveDescriptions()) {
 			Parameters.ParametersParameterComponent designation = parameters.addParameter().setName(DESIGNATION);
-			// TODO: what is the part name (or names) for DUC? As there are three parts of the DUC extension
-			// 	and there is one "bunch" of three per acceptability some object is needed to collect the DUC components.
-			// 	Further, with other values for degination.use might lead to multiple designations for the same description.
+			// 	TODO: with other values for degination.use might lead to multiple designations for the same description.
 			d.getAcceptabilityMap().forEach((langRefsetId, acceptability) -> {
-				// TODO: Is the name of the part correct? "The name of the parameter (reference to the operation definition)."
-				//	Reference to DUC extension?
 				Extension ducExt = new Extension("http://snomed.info/fhir/StructureDefinition/designation-use-context");
 				ducExt.addExtension("context", new Coding(SNOMED_URI, langRefsetId, null)); // TODO: is there a quick way to find a description for an id? Which description? Could be in any module/branch path.
 				// Add acceptability

--- a/src/main/java/org/snomed/snowstorm/fhir/services/HapiParametersMapper.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/HapiParametersMapper.java
@@ -138,6 +138,8 @@ public class HapiParametersMapper implements FHIRConstants {
 	private void addDesignations(Parameters parameters, Concept c) {
 		for (Description d : c.getActiveDescriptions()) {
 			Parameters.ParametersParameterComponent designation = parameters.addParameter().setName(DESIGNATION);
+			// TODO: add designation use context, see: src/main/java/org/snomed/snowstorm/fhir/services/HapiValueSetMapper.java
+			// private ConceptReferenceDesignationComponent asDesignation(Description d);
 			designation.addPart().setName(LANGUAGE).setValue(new CodeType(d.getLang()));
 			designation.addPart().setName(USE).setValue(new Coding(SNOMED_URI, d.getTypeId(), FHIRHelper.translateDescType(d.getTypeId())));
 			designation.addPart().setName(VALUE).setValue(new StringType(d.getTerm()));

--- a/src/main/java/org/snomed/snowstorm/fhir/services/HapiParametersMapper.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/HapiParametersMapper.java
@@ -158,6 +158,7 @@ public class HapiParametersMapper implements FHIRConstants {
 			});
 
 			designation.addPart().setName(LANGUAGE).setValue(new CodeType(d.getLang()));
+			// TODO: use FHIR designation.use value set, e.g. "consumer" when an appropriate language reference set is used
 			designation.addPart().setName(USE).setValue(new Coding(SNOMED_URI, d.getTypeId(), FHIRHelper.translateDescType(d.getTypeId())));
 			designation.addPart().setName(VALUE).setValue(new StringType(d.getTerm()));
 		}

--- a/src/main/java/org/snomed/snowstorm/fhir/services/HapiValueSetMapper.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/HapiValueSetMapper.java
@@ -74,7 +74,7 @@ public class HapiValueSetMapper implements FHIRConstants {
 			// Create designation use context Extension object using the URI
 			Extension ducExt = new Extension("http://snomed.info/fhir/StructureDefinition/designation-use-context"); // TODO: are there FHIR constants anywhere?
 			// Add the context, i.e. the language reference set
-			ducExt.addExtension("context", new Coding(SNOMED_URI, langRefsetId, null)); // TODO: is there a quick way to find a description for an id? Which description?
+			ducExt.addExtension("context", new Coding(SNOMED_URI, langRefsetId, null)); // TODO: is there a quick way to find a description for an id? Which description? Could be in any module/branch path.
 			// Add acceptability
 			switch(acceptability) {
 			case Concepts.ACCEPTABLE_CONSTANT:

--- a/src/main/java/org/snomed/snowstorm/fhir/services/HapiValueSetMapper.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/HapiValueSetMapper.java
@@ -79,6 +79,7 @@ public class HapiValueSetMapper implements FHIRConstants {
 			switch(acceptability) {
 			case Concepts.ACCEPTABLE_CONSTANT:
 				ducExt.addExtension("role", new Coding(SNOMED_URI, Concepts.ACCEPTABLE, Concepts.ACCEPTABLE_CONSTANT));
+				break;
 			case Concepts.PREFERRED_CONSTANT:
 				ducExt.addExtension("role", new Coding(SNOMED_URI, Concepts.PREFERRED, Concepts.PREFERRED_CONSTANT));
 			};

--- a/src/main/java/org/snomed/snowstorm/fhir/services/HapiValueSetMapper.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/HapiValueSetMapper.java
@@ -77,9 +77,9 @@ public class HapiValueSetMapper implements FHIRConstants {
 			ducExt.addExtension("context", new Coding(SNOMED_URI, langRefsetId, null)); // TODO: is there a quick way to find a description for an id? Which description?
 			// Add acceptability
 			switch(acceptability) {
-			case "ACCEPTABLE":
+			case Concepts.ACCEPTABLE_CONSTANT:
 				ducExt.addExtension("role", new Coding(SNOMED_URI, Concepts.ACCEPTABLE, Concepts.ACCEPTABLE_CONSTANT));
-			case "PREFERRED":
+			case Concepts.PREFERRED_CONSTANT:
 				ducExt.addExtension("role", new Coding(SNOMED_URI, Concepts.PREFERRED, Concepts.PREFERRED_CONSTANT));
 			};
 			// Add type, this is sometimes but not always redundant to designation.use!

--- a/src/test/java/org/snomed/snowstorm/fhir/services/ValueSetProviderEclTest.java
+++ b/src/test/java/org/snomed/snowstorm/fhir/services/ValueSetProviderEclTest.java
@@ -176,6 +176,9 @@ class ValueSetProviderEclTest extends AbstractFHIRTest {
 		assertEquals(1,v.getExpansion().getContains().size());
 		assertFalse(v.getExpansion().getContains().get(0).getDesignation().isEmpty());
 		assertNotNull(v.getExpansion().getContains().get(0).getDesignation().get(0).getExtensionByUrl("http://snomed.info/fhir/StructureDefinition/designation-use-context"));
+		assertNotNull(v.getExpansion().getContains().get(0).getDesignation().get(0).getExtensionByUrl("http://snomed.info/fhir/StructureDefinition/designation-use-context").getExtensionByUrl("context"));
+		assertNotNull(v.getExpansion().getContains().get(0).getDesignation().get(0).getExtensionByUrl("http://snomed.info/fhir/StructureDefinition/designation-use-context").getExtensionByUrl("role"));
+		assertNotNull(v.getExpansion().getContains().get(0).getDesignation().get(0).getExtensionByUrl("http://snomed.info/fhir/StructureDefinition/designation-use-context").getExtensionByUrl("type"));
 	}
 	
 	private void storeVs(String id, String vsJson) {

--- a/src/test/java/org/snomed/snowstorm/fhir/services/ValueSetProviderEclTest.java
+++ b/src/test/java/org/snomed/snowstorm/fhir/services/ValueSetProviderEclTest.java
@@ -168,6 +168,15 @@ class ValueSetProviderEclTest extends AbstractFHIRTest {
 		ValueSet v = getValueSet(url);
 		assertEquals(14,v.getExpansion().getContains().size());
 	}
+
+	@Test
+	void testECLWithDesignationUseContextExpansion() throws FHIROperationException {
+		String url = "http://localhost:" + port + "/fhir/ValueSet/$expand?url=http://snomed.info/sct/1234?fhir_vs=ecl/" + sampleSCTID +"&includeDesignations=true&_format=json";
+		ValueSet v = getValueSet(url);
+		assertEquals(1,v.getExpansion().getContains().size());
+		assertFalse(v.getExpansion().getContains().get(0).getDesignation().isEmpty());
+		assertNotNull(v.getExpansion().getContains().get(0).getDesignation().get(0).getExtensionByUrl("http://snomed.info/fhir/StructureDefinition/designation-use-context"));
+	}
 	
 	private void storeVs(String id, String vsJson) {
 		HttpEntity<String> request = new HttpEntity<>(vsJson, headers);


### PR DESCRIPTION
Raised on behalf of @danka74 (originally #307)

"First attempt at implementing DUC FHIR extension: https://confluence.ihtsdotools.org/display/FHIR/Designation+extension
There are some things to discuss, e.g. how to turn this on or off or otherwise control the use of the extension.
Also, only added this for ValueSet expansion and not for CodeSystem lookup (but should be similar)."