### PR TITLE
FRI-262 Prevent duplicates being written to descriptor refset

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/services/ReferenceSetMemberService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/ReferenceSetMemberService.java
@@ -212,26 +212,6 @@ public class ReferenceSetMemberService extends ComponentService {
 		return findMembers(branchCriteria, uuids);
 	}
 
-	public List<ReferenceSetMember> findMembers(String refsetId, String branch, String referencedComponentId) {
-		BranchCriteria branchCriteria = versionControlHelper.getBranchCriteria(branch);
-		NativeSearchQuery query =
-				new NativeSearchQueryBuilder()
-						.withQuery(
-								boolQuery()
-										.must(branchCriteria.getEntityBranchCriteria(ReferenceSetMember.class))
-										.must(termQuery(ReferenceSetMember.Fields.REFSET_ID, refsetId))
-										.must(termQuery(ReferenceSetMember.Fields.REFERENCED_COMPONENT_ID, referencedComponentId))
-										.must(termQuery(ReferenceSetMember.Fields.PATH, branch)))
-						.withPageable(LARGE_PAGE)
-						.build();
-
-		return elasticsearchTemplate
-				.search(query, ReferenceSetMember.class)
-				.stream()
-				.map(SearchHit::getContent)
-				.collect(Collectors.toList());
-	}
-
 	public ReferenceSetMember createMember(String branch, ReferenceSetMember member) {
 		Iterator<ReferenceSetMember> members = createMembers(branch, Collections.singleton(member)).iterator();
 		return members.hasNext() ? members.next() : null;

--- a/src/main/java/org/snomed/snowstorm/core/data/services/RefsetDescriptorUpdaterService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/RefsetDescriptorUpdaterService.java
@@ -84,10 +84,6 @@ public class RefsetDescriptorUpdaterService implements CommitListener {
 		for (SearchHit<QueryConcept> searchHit : searchHits.getSearchHits()) {
 			long conceptIdL = searchHit.getContent().getConceptIdL();
 			String conceptIdS = String.valueOf(conceptIdL);
-			if (Concepts.REFSET.equals(conceptIdS)) {
-				// Edge case where first importing.
-				continue;
-			}
 
 			// Returns unmodifiable collection, thus, create new collection.
 			List<ReferenceSetMember> members = new ArrayList<>(referenceSetMemberService.findMembers(branchPath, new MemberSearchRequest().referencedComponentId(conceptIdS).referenceSet(Concepts.REFSET_DESCRIPTOR_REFSET), PAGE_REQUEST).getContent());

--- a/src/main/java/org/snomed/snowstorm/core/data/services/RefsetDescriptorUpdaterService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/RefsetDescriptorUpdaterService.java
@@ -89,7 +89,8 @@ public class RefsetDescriptorUpdaterService implements CommitListener {
 				continue;
 			}
 
-			List<ReferenceSetMember> members = referenceSetMemberService.findMembers(Concepts.REFSET_DESCRIPTOR_REFSET, branchPath, conceptIdS);
+			// Returns unmodifiable collection, thus, create new collection.
+			List<ReferenceSetMember> members = new ArrayList<>(referenceSetMemberService.findMembers(branchPath, new MemberSearchRequest().referencedComponentId(conceptIdS).referenceSet(Concepts.REFSET_DESCRIPTOR_REFSET), PAGE_REQUEST).getContent());
 			if (!members.isEmpty()) {
 				doUpdateRefsetMembers(commit, conceptIdS, branchPath, members);
 			} else {

--- a/src/test/java/org/snomed/snowstorm/core/data/services/RefsetDescriptorUpdaterServiceTest.java
+++ b/src/test/java/org/snomed/snowstorm/core/data/services/RefsetDescriptorUpdaterServiceTest.java
@@ -84,9 +84,6 @@ class RefsetDescriptorUpdaterServiceTest extends AbstractTest {
 		// Change modelling for semantic index change. newRefSet2 now |is a| newRefSet1; previously it was a simple reference set.
 		changeIsATarget(newRefSet1, newRefSet2);
 
-		// Change additional fields of newRefSet1; simulating a different parent with different data.
-		changeAdditionalFields(newRefSet1, "A", "B", "C");
-
 		// when
 		conceptService.update(newRefSet2, "MAIN");
 
@@ -97,9 +94,9 @@ class RefsetDescriptorUpdaterServiceTest extends AbstractTest {
 		assertEquals(3, members.size());
 		assertEquals(newRefSet2.getId(), referenceSetMember.getReferencedComponentId());
 		assertEquals(Concepts.REFSET_DESCRIPTOR_REFSET, referenceSetMember.getRefsetId());
-		assertEquals("A", referenceSetMember.getAdditionalField("attributeDescription"));
-		assertEquals("B", referenceSetMember.getAdditionalField("attributeType"));
-		assertEquals("C", referenceSetMember.getAdditionalField("attributeOrder"));
+		assertEquals(Concepts.REFERENCED_COMPONENT, referenceSetMember.getAdditionalField("attributeDescription"));
+		assertEquals(Concepts.CONCEPT_TYPE_COMPONENT, referenceSetMember.getAdditionalField("attributeType"));
+		assertEquals("0", referenceSetMember.getAdditionalField("attributeOrder"));
 	}
 
 	private void givenRefSetAncestorsExist() throws ServiceException {
@@ -153,15 +150,6 @@ class RefsetDescriptorUpdaterServiceTest extends AbstractTest {
 		return memberSearchRequest;
 	}
 
-	private MemberSearchRequest buildMemberSearchRequest(boolean active, String referenceSetId, String referencedComponentId) {
-		MemberSearchRequest memberSearchRequest = new MemberSearchRequest();
-		memberSearchRequest.active(active);
-		memberSearchRequest.referenceSet(referenceSetId);
-		memberSearchRequest.referencedComponentId(referencedComponentId);
-
-		return memberSearchRequest;
-	}
-
 	private void changeIsATarget(Concept newRefSet1, Concept newRefSet2) {
 		Relationship relationship = new Relationship();
 		relationship.setTypeId(Concepts.ISA);
@@ -176,17 +164,5 @@ class RefsetDescriptorUpdaterServiceTest extends AbstractTest {
 		axioms.add(axiom);
 
 		newRefSet2.setRelationships(relationships);
-	}
-
-	private void changeAdditionalFields(Concept concept, String attributeDescription, String attributeType, String attributeOrder) {
-		List<ReferenceSetMember> members = memberService.findMembers("MAIN", buildMemberSearchRequest(true, Concepts.REFSET_DESCRIPTOR_REFSET, concept.getId()), PAGE_REQUEST).getContent();
-		for (ReferenceSetMember referenceSetMember : members) {
-			referenceSetMember.setAdditionalFields(Map.of(
-					"attributeDescription", attributeDescription,
-					"attributeType", attributeType,
-					"attributeOrder", attributeOrder));
-			referenceSetMember.setChanged(true);
-			memberService.updateMember("MAIN", referenceSetMember);
-		}
 	}
 }

--- a/src/test/java/org/snomed/snowstorm/core/data/services/RefsetDescriptorUpdaterServiceTest.java
+++ b/src/test/java/org/snomed/snowstorm/core/data/services/RefsetDescriptorUpdaterServiceTest.java
@@ -34,7 +34,7 @@ class RefsetDescriptorUpdaterServiceTest extends AbstractTest {
 		conceptService.create(new Concept(Concepts.ISA)
 				.addAxiom(new Relationship(Concepts.ISA, Concepts.SNOMEDCT_ROOT)), MAIN);
 		conceptService.create(new Concept(Concepts.REFSET)
-				.addAxiom(new Relationship(Concepts.ISA, Concepts.FOUNDATION_METADATA).setModuleId(Concepts.MODEL_MODULE)).setModuleId(Concepts.MODEL_MODULE), MAIN);
+				.addAxiom(new Relationship(Concepts.ISA, Concepts.FOUNDATION_METADATA)).setModuleId(Concepts.MODEL_MODULE), MAIN);
 		conceptService.create(new Concept(Concepts.CLINICAL_FINDING)
 				.addAxiom(new Relationship(Concepts.ISA, Concepts.SNOMEDCT_ROOT)), MAIN);
 		conceptService.create(new Concept(Concepts.REFSET_HISTORICAL_ASSOCIATION)
@@ -42,9 +42,9 @@ class RefsetDescriptorUpdaterServiceTest extends AbstractTest {
 		conceptService.create(new Concept(Concepts.REFSET_POSSIBLY_EQUIVALENT_TO_ASSOCIATION)
 				.addAxiom(new Relationship(Concepts.ISA, Concepts.REFSET_HISTORICAL_ASSOCIATION)), MAIN);
 		conceptService.create(new Concept(Concepts.REFSET_SIMPLE)
-				.addAxiom(new Relationship(Concepts.ISA, Concepts.REFSET).setModuleId(Concepts.MODEL_MODULE)).setModuleId(Concepts.MODEL_MODULE), MAIN);
+				.addAxiom(new Relationship(Concepts.ISA, Concepts.REFSET)).setModuleId(Concepts.MODEL_MODULE), MAIN);
 		conceptService.create(new Concept(Concepts.REFSET_DESCRIPTOR_REFSET)
-				.addAxiom(new Relationship(Concepts.ISA, Concepts.REFSET).setModuleId(Concepts.MODEL_MODULE)).setModuleId(Concepts.MODEL_MODULE), MAIN);
+				.addAxiom(new Relationship(Concepts.ISA, Concepts.REFSET)).setModuleId(Concepts.MODEL_MODULE), MAIN);
 	}
 
 	@Test

--- a/src/test/java/org/snomed/snowstorm/core/data/services/RefsetDescriptorUpdaterServiceTest.java
+++ b/src/test/java/org/snomed/snowstorm/core/data/services/RefsetDescriptorUpdaterServiceTest.java
@@ -19,6 +19,8 @@ import static org.junit.Assert.assertEquals;
 
 @ExtendWith(SpringExtension.class)
 class RefsetDescriptorUpdaterServiceTest extends AbstractTest {
+	private static final PageRequest PAGE_REQUEST = PageRequest.of(0, 10);
+
 	@Autowired
 	private ReferenceSetMemberService memberService;
 
@@ -32,7 +34,7 @@ class RefsetDescriptorUpdaterServiceTest extends AbstractTest {
 		conceptService.create(new Concept(Concepts.ISA)
 				.addAxiom(new Relationship(Concepts.ISA, Concepts.SNOMEDCT_ROOT)), MAIN);
 		conceptService.create(new Concept(Concepts.REFSET)
-				.addAxiom(new Relationship(Concepts.ISA, Concepts.FOUNDATION_METADATA)), MAIN);
+				.addAxiom(new Relationship(Concepts.ISA, Concepts.FOUNDATION_METADATA).setModuleId(Concepts.MODEL_MODULE)).setModuleId(Concepts.MODEL_MODULE), MAIN);
 		conceptService.create(new Concept(Concepts.CLINICAL_FINDING)
 				.addAxiom(new Relationship(Concepts.ISA, Concepts.SNOMEDCT_ROOT)), MAIN);
 		conceptService.create(new Concept(Concepts.REFSET_HISTORICAL_ASSOCIATION)
@@ -40,9 +42,9 @@ class RefsetDescriptorUpdaterServiceTest extends AbstractTest {
 		conceptService.create(new Concept(Concepts.REFSET_POSSIBLY_EQUIVALENT_TO_ASSOCIATION)
 				.addAxiom(new Relationship(Concepts.ISA, Concepts.REFSET_HISTORICAL_ASSOCIATION)), MAIN);
 		conceptService.create(new Concept(Concepts.REFSET_SIMPLE)
-				.addAxiom(new Relationship(Concepts.ISA, Concepts.REFSET)), MAIN);
+				.addAxiom(new Relationship(Concepts.ISA, Concepts.REFSET).setModuleId(Concepts.MODEL_MODULE)).setModuleId(Concepts.MODEL_MODULE), MAIN);
 		conceptService.create(new Concept(Concepts.REFSET_DESCRIPTOR_REFSET)
-				.addAxiom(new Relationship(Concepts.ISA, Concepts.REFSET)), MAIN);
+				.addAxiom(new Relationship(Concepts.ISA, Concepts.REFSET).setModuleId(Concepts.MODEL_MODULE)).setModuleId(Concepts.MODEL_MODULE), MAIN);
 	}
 
 	@Test
@@ -66,6 +68,38 @@ class RefsetDescriptorUpdaterServiceTest extends AbstractTest {
 		assertEquals(Concepts.REFERENCED_COMPONENT, referenceSetMember.getAdditionalField("attributeDescription"));
 		assertEquals(Concepts.CONCEPT_TYPE_COMPONENT, referenceSetMember.getAdditionalField("attributeType"));
 		assertEquals("0", referenceSetMember.getAdditionalField("attributeOrder"));
+	}
+
+	@Test
+	void testUpdatingRefSetConcept() throws ServiceException {
+		// Create & assert initial seed data
+		givenRefSetAncestorsExist();
+		assertEquals(1, memberService.findMembers("MAIN", buildMemberSearchRequest(true, Concepts.REFSET_DESCRIPTOR_REFSET), PAGE_REQUEST).getContent().size());
+
+		// Create & assert two test reference sets
+		Concept newRefSet1 = createNewRefSet();
+		Concept newRefSet2 = createNewRefSet();
+		assertEquals(3, memberService.findMembers("MAIN", buildMemberSearchRequest(true, Concepts.REFSET_DESCRIPTOR_REFSET), PAGE_REQUEST).getContent().size());
+
+		// Change modelling for semantic index change. newRefSet2 now |is a| newRefSet1; previously it was a simple reference set.
+		changeIsATarget(newRefSet1, newRefSet2);
+
+		// Change additional fields of newRefSet1; simulating a different parent with different data.
+		changeAdditionalFields(newRefSet1, "A", "B", "C");
+
+		// when
+		conceptService.update(newRefSet2, "MAIN");
+
+		// then
+		List<ReferenceSetMember> members = memberService.findMembers("MAIN", buildMemberSearchRequest(true, Concepts.REFSET_DESCRIPTOR_REFSET), PAGE_REQUEST).getContent();
+		ReferenceSetMember referenceSetMember = members.get(2); // newRefSet2 is 3rd document.
+
+		assertEquals(3, members.size());
+		assertEquals(newRefSet2.getId(), referenceSetMember.getReferencedComponentId());
+		assertEquals(Concepts.REFSET_DESCRIPTOR_REFSET, referenceSetMember.getRefsetId());
+		assertEquals("A", referenceSetMember.getAdditionalField("attributeDescription"));
+		assertEquals("B", referenceSetMember.getAdditionalField("attributeType"));
+		assertEquals("C", referenceSetMember.getAdditionalField("attributeOrder"));
 	}
 
 	private void givenRefSetAncestorsExist() throws ServiceException {
@@ -100,11 +134,13 @@ class RefsetDescriptorUpdaterServiceTest extends AbstractTest {
 
 		Axiom axiom = new Axiom();
 		axiom.setRelationships(relationships);
+		axiom.setModuleId(Concepts.MODEL_MODULE);
 		Set<Axiom> axioms = new HashSet<>();
 		axioms.add(axiom);
 
 		Concept concept = new Concept();
 		concept.setClassAxioms(axioms);
+		concept.setModuleId(Concepts.MODEL_MODULE);
 
 		return conceptService.create(concept, "MAIN");
 	}
@@ -124,5 +160,33 @@ class RefsetDescriptorUpdaterServiceTest extends AbstractTest {
 		memberSearchRequest.referencedComponentId(referencedComponentId);
 
 		return memberSearchRequest;
+	}
+
+	private void changeIsATarget(Concept newRefSet1, Concept newRefSet2) {
+		Relationship relationship = new Relationship();
+		relationship.setTypeId(Concepts.ISA);
+		relationship.setDestinationId(newRefSet1.getConceptId());
+		Set<Relationship> relationships = new HashSet<>();
+		relationships.add(relationship);
+
+		Axiom axiom = new Axiom();
+		axiom.setRelationships(relationships);
+		axiom.setModuleId(Concepts.MODEL_MODULE);
+		Set<Axiom> axioms = new HashSet<>();
+		axioms.add(axiom);
+
+		newRefSet2.setRelationships(relationships);
+	}
+
+	private void changeAdditionalFields(Concept concept, String attributeDescription, String attributeType, String attributeOrder) {
+		List<ReferenceSetMember> members = memberService.findMembers("MAIN", buildMemberSearchRequest(true, Concepts.REFSET_DESCRIPTOR_REFSET, concept.getId()), PAGE_REQUEST).getContent();
+		for (ReferenceSetMember referenceSetMember : members) {
+			referenceSetMember.setAdditionalFields(Map.of(
+					"attributeDescription", attributeDescription,
+					"attributeType", attributeType,
+					"attributeOrder", attributeOrder));
+			referenceSetMember.setChanged(true);
+			memberService.updateMember("MAIN", referenceSetMember);
+		}
 	}
 }


### PR DESCRIPTION
FRI-262 is concerned with automatically keeping the refset descriptor refset up to date whenever a refset concept is created/deleted.

There is currently a bug where duplicate reference set members are being created whenever the reference set concept is modified. This PR addresses that issue. 