### PR TITLE
FRI-27 Consume Classification status via JMS

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/services/classification/ClassificationService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/classification/ClassificationService.java
@@ -184,7 +184,7 @@ public class ClassificationService {
 							synchronized (classificationUserIdToUserContextMap) {
 								SecurityContextHolder.setContext(classificationUserIdToUserContextMap.get(classification.getUserId()));
 							}
-							ClassificationStatusResponse statusResponse = serviceClient.getStatus(classification.getId());
+							ClassificationStatusResponse statusResponse = serviceClient.getStatusChange(classification.getId());
 							ClassificationStatus newStatus = statusResponse.getStatus();
 							boolean timeout = false;
 

--- a/src/main/java/org/snomed/snowstorm/core/data/services/classification/ClassificationStatusService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/classification/ClassificationStatusService.java
@@ -1,0 +1,7 @@
+package org.snomed.snowstorm.core.data.services.classification;
+
+import org.snomed.snowstorm.core.data.services.classification.pojo.ClassificationStatusResponse;
+
+public interface ClassificationStatusService {
+	ClassificationStatusResponse getStatusChange(String classificationId);
+}

--- a/src/main/java/org/snomed/snowstorm/core/data/services/classification/JMSListenerClassificationStatusService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/classification/JMSListenerClassificationStatusService.java
@@ -1,0 +1,49 @@
+package org.snomed.snowstorm.core.data.services.classification;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.activemq.command.ActiveMQTextMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.snomed.snowstorm.core.data.services.classification.pojo.ClassificationStatusResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.jms.annotation.JmsListener;
+import org.springframework.stereotype.Component;
+
+import javax.jms.JMSException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@ConditionalOnProperty(value = "classification-service.job.status.use-jms", havingValue = "true")
+public class JMSListenerClassificationStatusService implements ClassificationStatusService {
+	private static final Logger LOGGER = LoggerFactory.getLogger(JMSListenerClassificationStatusService.class);
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+	private final Map<String, ClassificationStatusResponse> classificationStatusChanges = Collections.synchronizedMap(new HashMap<>());
+
+	public JMSListenerClassificationStatusService(@Value("${classification-service.job.status.location}") String responseMessageQueue) {
+		if (responseMessageQueue == null || responseMessageQueue.isEmpty()) {
+			throw new IllegalStateException("No queue specified");
+		}
+	}
+
+	@JmsListener(destination = "${classification-service.job.status.location}")
+	void messageConsumer(ActiveMQTextMessage activeMQTextMessage) throws JMSException, JsonProcessingException {
+		try {
+			ClassificationStatusResponse response = objectMapper.readValue(activeMQTextMessage.getText(), ClassificationStatusResponse.class);
+			classificationStatusChanges.put(response.getId(), response);
+		} catch (JsonParseException | JsonMappingException e) {
+			LOGGER.error("Failed to parse message. Message: {}.", activeMQTextMessage.getText());
+		}
+	}
+
+	@Override
+	public ClassificationStatusResponse getStatusChange(String classificationId) {
+		return classificationStatusChanges.remove(classificationId);
+	}
+}

--- a/src/main/java/org/snomed/snowstorm/core/data/services/classification/RestTemplateClassificationStatusService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/classification/RestTemplateClassificationStatusService.java
@@ -1,0 +1,34 @@
+package org.snomed.snowstorm.core.data.services.classification;
+
+import org.snomed.snowstorm.core.data.services.classification.pojo.ClassificationStatusResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@ConditionalOnProperty(value = "classification-service.job.status.use-jms", havingValue = "false")
+public class RestTemplateClassificationStatusService implements ClassificationStatusService {
+
+	private final RestTemplate restTemplate;
+
+	public RestTemplateClassificationStatusService(@Value("${classification-service.url}") String serviceUrl,
+												   @Value("${classification-service.username}") String serviceUsername,
+												   @Value("${classification-service.password}") String servicePassword,
+												   @Value("${classification-service.job.status.location}") String responseMessageQueue) {
+		if (responseMessageQueue != null && !responseMessageQueue.isEmpty()) {
+			throw new IllegalStateException("Queue specified but not required for this strategy.");
+		}
+
+		restTemplate = new RestTemplateBuilder()
+				.rootUri(serviceUrl)
+				.basicAuthentication(serviceUsername, servicePassword)
+				.build();
+	}
+
+	@Override
+	public ClassificationStatusResponse getStatusChange(String classificationId) {
+		return restTemplate.getForObject("/classifications/{classificationId}", ClassificationStatusResponse.class, classificationId);
+	}
+}

--- a/src/main/java/org/snomed/snowstorm/core/data/services/classification/pojo/ClassificationStatusResponse.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/classification/pojo/ClassificationStatusResponse.java
@@ -6,9 +6,18 @@ import org.snomed.snowstorm.core.data.domain.classification.ClassificationStatus
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ClassificationStatusResponse {
 
+	private String id;
 	private ClassificationStatus status;
 	private String errorMessage;
 	private String developerMessage;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
 
 	public ClassificationStatus getStatus() {
 		return status;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -303,6 +303,11 @@ classification-service.password=
 # Classification Job Timeout in minutes
 classification-service.job.abort-after-minutes=45
 
+# Strategy to retrieve status of a classification. False by default for backward compatibility.
+classification-service.job.status.use-jms=false
+
+# Queue containing the status of a classification. Blank by default for backward compatibility.
+classification-service.job.status.location=
 
 # ----------------------------------------
 # Service Commit Hooks


### PR DESCRIPTION
FRI-27 is concerned with updating Snowstorm to retrieve a Classification's status via JMS instead of HTTP.

This PR changes Snowstorm to request Classifications be written to a new queue and to listen to the new queue for Classification status updates. 