### PR TITLE
Fix #352 dailybuild rollback error when large number of versionsreplaced

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/services/SBranchService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/SBranchService.java
@@ -89,13 +89,15 @@ public class SBranchService {
 		return branch;
 	}
 
-	public Page<Branch> findAllVersionsAfterOrEqualToTimestamp(String path, Date timestamp, Pageable pageable) {
+	public Page<Branch> findAllVersionsAfterOrEqualToTimestampAsLightCommits(String path, Date timestamp, Pageable pageable) {
 		NativeSearchQueryBuilder queryBuilder = new NativeSearchQueryBuilder()
 				.withQuery(boolQuery()
 						.must(QueryBuilders.termQuery("path", path))
 						.must(QueryBuilders.rangeQuery("start").gte(timestamp.getTime())))
+				.withFields("path", "start", "end", "head", "base", "locked")
 				.withSort(SortBuilders.fieldSort("start"))
 				.withPageable(pageable);
+
 		SearchHits<Branch> searchHits = elasticsearchTemplate.search(queryBuilder.build(), Branch.class);
 		return new PageImpl<>(searchHits.get().map(SearchHit::getContent).collect(Collectors.toList()),
 				pageable, searchHits.getTotalHits());

--- a/src/main/java/org/snomed/snowstorm/dailybuild/DailyBuildService.java
+++ b/src/main/java/org/snomed/snowstorm/dailybuild/DailyBuildService.java
@@ -125,36 +125,37 @@ public class DailyBuildService {
 		Date baseForReleaseCommit = null;
 		Date baseForUpgradeCommit = null;
 		if (releaseCommitHead != null) {
-			List<Branch> commits = sBranchService.findAllVersionsAfterOrEqualToTimestamp(branchPath, releaseCommitHead, Pageable.unpaged()).getContent();
-			logger.info("{} commits found on {} since latest release.", commits.size() - 1, branchPath);
-			for (Branch commit : commits) {
+			List<Branch> lightCommits = sBranchService.findAllVersionsAfterOrEqualToTimestampAsLightCommits(branchPath, releaseCommitHead, Pageable.unpaged()).getContent();
+			logger.info("{} commits found on {} since latest release.", lightCommits.size() - 1, branchPath);
+			for (Branch lightCommit : lightCommits) {
 				// Don't rollback the release commit
-				if (commit.getHead().equals(releaseCommitHead)) {
-					baseForReleaseCommit = commit.getBase();
+				if (lightCommit.getHead().equals(releaseCommitHead)) {
+					baseForReleaseCommit = lightCommit.getBase();
 					commitsToRollback.clear();
 					logger.info("Release commit found, base version {} recorded.", baseForReleaseCommit.getTime());
 					continue;
 				}
 				// Exclude additional upgrade commits after code system version
-				if (baseForUpgradeCommit != null && !commit.getBase().equals(baseForUpgradeCommit)) {
+				if (baseForUpgradeCommit != null && !lightCommit.getBase().equals(baseForUpgradeCommit)) {
 					logger.info("Commit {} has base {} which is different to the last upgrade commit. " +
 									"This upgrade commit will not be rolled back nor will any commits before this.",
-							commit.getHeadTimestamp(), commit.getBaseTimestamp());
-					baseForUpgradeCommit = commit.getBase();
+							lightCommit.getHeadTimestamp(), lightCommit.getBaseTimestamp());
+					baseForUpgradeCommit = lightCommit.getBase();
 					commitsToRollback.clear();
 					continue;
 				// Exclude first upgrade commit after code system version
-				} else if (baseForUpgradeCommit == null && baseForReleaseCommit != null && !commit.getBase().equals(baseForReleaseCommit)) {
+				} else if (baseForUpgradeCommit == null && baseForReleaseCommit != null && !lightCommit.getBase().equals(baseForReleaseCommit)) {
 					logger.info("Commit {} has base {} which is different to the release commit. " +
 									"This upgrade commit will not be rolled back nor will any commits before this.",
-							commit.getHeadTimestamp(), commit.getBaseTimestamp());
-					baseForUpgradeCommit = commit.getBase();
+							lightCommit.getHeadTimestamp(), lightCommit.getBaseTimestamp());
+					baseForUpgradeCommit = lightCommit.getBase();
 					commitsToRollback.clear();
 					continue;
 				} else {
 					logger.info("Commit {} does not have a new base ({}) so will be rolled back.",
-							commit.getHeadTimestamp(), commit.getBaseTimestamp());
+							lightCommit.getHeadTimestamp(), lightCommit.getBaseTimestamp());
 				}
+				Branch commit = branchService.findAtTimepointOrThrow(lightCommit.getPath(), lightCommit.getHead());
 				commitsToRollback.add(commit);
 			}
 		} else {
@@ -167,6 +168,7 @@ public class DailyBuildService {
 
 		// Roll back in reverse order (i.e the most recent first)
 		Collections.reverse(commitsToRollback);
+
 		rollbackCommits(branchPath, commitsToRollback);
 	}
 

--- a/src/test/java/org/snomed/snowstorm/dailybuild/DailyBuildServiceTest.java
+++ b/src/test/java/org/snomed/snowstorm/dailybuild/DailyBuildServiceTest.java
@@ -13,7 +13,6 @@ import org.snomed.snowstorm.TestConfig;
 import org.snomed.snowstorm.core.data.domain.CodeSystem;
 import org.snomed.snowstorm.core.data.domain.CodeSystemVersion;
 import org.snomed.snowstorm.core.data.domain.Concept;
-import org.snomed.snowstorm.core.data.services.AdminOperationsService;
 import org.snomed.snowstorm.core.data.services.CodeSystemService;
 import org.snomed.snowstorm.core.data.services.CodeSystemUpgradeService;
 import org.snomed.snowstorm.core.data.services.ConceptService;
@@ -23,17 +22,21 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 
-import static junit.framework.TestCase.*;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = TestConfig.class)
@@ -57,9 +60,6 @@ class DailyBuildServiceTest extends AbstractTest {
 	@Autowired
 	private CodeSystemUpgradeService codeSystemUpgradeService;
 
-	@Autowired
-	private AdminOperationsService adminOperationsService;
-
 	private File baseLineRelease;
 
 	private File rf2Archive1;
@@ -67,9 +67,6 @@ class DailyBuildServiceTest extends AbstractTest {
 	private File rf2Archive2;
 
 	private CodeSystem snomedct;
-
-	@Autowired
-	private ElasticsearchRestTemplate elasticsearchTemplate;
 
 	@Autowired
 	private ResourceLoader resourceLoader;


### PR DESCRIPTION
This fixes the case where somehow the branch documents since the last versioning commit are larger than 100MB. The fix filters the fields of the branch documents when loading a page of them then loads them one by one after filtering so that the 100MB limit is not triggered.