### PR TITLE
Fixes #367 return concept ids as strings when returnIdOnly param used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 7.7.0 Release
+
+### Breaking
+- General
+  - When using `returnIdOnly` parameter; the ids returned now use 'string' rather than 'number' JSON data type, to avoid rounding. Fixes #367.
+
+
 ## 7.5.4 Release (Dec 2021)
 Maintenance release with new features in FHIR and many improvements and fixes.
 

--- a/src/main/java/org/snomed/snowstorm/rest/ConceptController.java
+++ b/src/main/java/org/snomed/snowstorm/rest/ConceptController.java
@@ -23,6 +23,8 @@ import org.snomed.snowstorm.core.data.services.pojo.ResultMapPage;
 import org.snomed.snowstorm.core.pojo.BranchTimepoint;
 import org.snomed.snowstorm.core.pojo.LanguageDialect;
 import org.snomed.snowstorm.core.util.PageHelper;
+import org.snomed.snowstorm.core.util.SearchAfterPage;
+import org.snomed.snowstorm.core.util.SearchAfterPageImpl;
 import org.snomed.snowstorm.core.util.TimerUtil;
 import org.snomed.snowstorm.ecl.validation.ECLValidator;
 import org.snomed.snowstorm.rest.converter.SearchAfterHelper;
@@ -46,6 +48,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import javax.validation.Valid;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static io.kaicode.elasticvc.api.ComponentService.LARGE_PAGE;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -181,7 +184,10 @@ public class ConceptController {
 			pageRequest = getPageRequestWithSort(offset, limit, searchAfter, Sort.sort(QueryConcept.class).by(QueryConcept::getConceptIdL).descending());
 		}
 		if (returnIdOnly) {
-			return new ItemsPage<>(queryService.searchForIds(queryBuilder, branch, pageRequest));
+			SearchAfterPage<Long> longsPage = queryService.searchForIds(queryBuilder, branch, pageRequest);
+			SearchAfterPageImpl<String> stringPage = new SearchAfterPageImpl<>(longsPage.stream().map(Object::toString).collect(Collectors.toList()),
+					longsPage.getPageable(), longsPage.getTotalElements(), longsPage.getSearchAfter());
+			return new ItemsPage<>(stringPage);
 		} else {
 			return new ItemsPage<>(queryService.search(queryBuilder, branch, pageRequest));
 		}


### PR DESCRIPTION
Controller unit tests still pass.
Local manual tests look good:
<img width="900" alt="Screenshot 2022-01-31 at 16 18 19" src="https://user-images.githubusercontent.com/2010517/151831289-15e3a92a-6d14-4a71-9998-fa442adeba40.png">

Search after still works.