### PR TITLE
Add property latestDailyBuild

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/domain/CodeSystem.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/domain/CodeSystem.java
@@ -20,7 +20,7 @@ import java.util.Set;
  * Represents an edition or extension of SNOMED-CT
  */
 @Document(indexName = "codesystem")
-@JsonPropertyOrder({"name", "owner", "shortName", "branchPath", "dependantVersionEffectiveTime", "dailyBuildAvailable",
+@JsonPropertyOrder({"name", "owner", "shortName", "branchPath", "dependantVersionEffectiveTime", "dailyBuildAvailable", "latestDailyBuild",
 		"countryCode", "defaultLanguageCode", "defaultLanguageReferenceSets", "maintainerType", "latestVersion", "languages", "modules"})
 public class CodeSystem implements CodeSystemCreate {
 
@@ -59,6 +59,9 @@ public class CodeSystem implements CodeSystemCreate {
 
 	@Field(type = FieldType.Boolean)
 	private boolean dailyBuildAvailable;
+
+	@Field(type = FieldType.Keyword)
+	private String latestDailyBuild;
 
 	@Transient
 	private Integer dependantVersionEffectiveTime;
@@ -169,6 +172,14 @@ public class CodeSystem implements CodeSystemCreate {
 
 	public void setDailyBuildAvailable(boolean dailyBuildAvailable) {
 		this.dailyBuildAvailable = dailyBuildAvailable;
+	}
+
+	public String getLatestDailyBuild() {
+		return latestDailyBuild;
+	}
+
+	public void setLatestDailyBuild(String latestDailyBuild) {
+		this.latestDailyBuild = latestDailyBuild;
 	}
 
 	public Integer getDependantVersionEffectiveTime() {

--- a/src/main/java/org/snomed/snowstorm/dailybuild/DailyBuildService.java
+++ b/src/main/java/org/snomed/snowstorm/dailybuild/DailyBuildService.java
@@ -23,6 +23,7 @@ import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+import org.snomed.snowstorm.core.data.repositories.CodeSystemRepository;
 
 import javax.annotation.PostConstruct;
 import java.io.FileNotFoundException;
@@ -39,6 +40,9 @@ public class DailyBuildService {
 	private static final String DAILY_BUILD_DATE_FORMAT = "yyyy-MM-dd-HHmmss";
 	private static final String LOCK_MESSAGE = "Branch locked for daily build import.";
 
+	@Autowired
+	private CodeSystemRepository codeSystemRepository;
+	
 	@Autowired
 	private DailyBuildResourceConfig dailyBuildResourceConfig;
 
@@ -72,6 +76,17 @@ public class DailyBuildService {
 		resourceManager = new ResourceManager(dailyBuildResourceConfig, resourceLoader);
 	}
 
+	public boolean hasLatestDailyBuild(String shortName) {
+		CodeSystem codeSystem = codeSystemService.findOrThrow(shortName);
+		String latestDailyBuild = codeSystem.getLatestDailyBuild();         
+		if (latestDailyBuild == null || latestDailyBuild.length() == 0) {
+			return false;
+		}  
+		latestDailyBuild = latestDailyBuild.substring(0, latestDailyBuild.lastIndexOf("-"));
+		SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+		return latestDailyBuild.equals(formatter.format(new Date()));
+	}
+
 	void performScheduledImport(CodeSystem codeSystem) throws IOException, ReleaseImportException {
 		String branchPath = codeSystem.getBranchPath();
 		Branch codeSystemBranch = branchService.findBranchOrThrow(branchPath);
@@ -103,6 +118,8 @@ public class DailyBuildService {
 			importService.importArchive(importId, dailyBuildStream);
 		}
 		logger.info("Daily build delta import completed for code system {}", codeSystem.getShortName());
+		codeSystem.setLatestDailyBuild(dailyBuildFilename.substring(0, dailyBuildFilename.lastIndexOf(".")));
+		codeSystemRepository.save(codeSystem);
 	}
 
 	@PreAuthorize("hasPermission('ADMIN', #codeSystem.branchPath)")
@@ -170,6 +187,8 @@ public class DailyBuildService {
 		Collections.reverse(commitsToRollback);
 
 		rollbackCommits(branchPath, commitsToRollback);
+		codeSystem.setLatestDailyBuild("");
+		codeSystemRepository.save(codeSystem);
 	}
 
 	private void rollbackCommits(String path, List<Branch> rollbackList) {

--- a/src/main/java/org/snomed/snowstorm/rest/CodeSystemController.java
+++ b/src/main/java/org/snomed/snowstorm/rest/CodeSystemController.java
@@ -183,6 +183,12 @@ public class CodeSystemController {
 		codeSystemUpgradeService.upgrade(codeSystem, request.getNewDependantVersion(), TRUE.equals(request.getContentAutomations()));
 	}
 
+	@ApiOperation("Check if daily build import matches today's date.")
+	@RequestMapping(value = "/{shortName}/daily-build/check", method = RequestMethod.GET)
+	public boolean getLatestDailyBuild(@PathVariable String shortName) {
+		return dailyBuildService.hasLatestDailyBuild(shortName);
+	}
+
 	@ApiOperation(value = "Rollback daily build commits.",
 			notes = "If you have a daily build set up for a code system this operation should be used to revert/rollback the daily build content " +
 					"before importing any versioned content. Be sure to disable the daily build too.")


### PR DESCRIPTION
Aim of the pull request is to make it more obvious for users how to find the latest db. Current ways of inspecting branches or checking authoring stats doesn't give a simple answer to the questions: has the db been loaded today, and if so, which version has Snowstorm loaded?

Two things here:
1. Added a property to codesystems: latestDailyBuild
2. A small endpoint which only checks latestDailyBuild against today's date. Obviously, this isn't a 'necessary' endpoint to add. The rationale behind it was to move that logic from the client to Snowstorm to enable users to use simpler alerts/notification tools (or for non-technical users who cannot define that logic themselves) for triggering a failed db alert. 