### PR TITLE
MAINT-1882 Snowstorm IPS Import without MRCM

### DIFF
--- a/src/test/java/org/snomed/snowstorm/core/data/services/SemanticIndexUpdateServiceTest.java
+++ b/src/test/java/org/snomed/snowstorm/core/data/services/SemanticIndexUpdateServiceTest.java
@@ -1097,15 +1097,13 @@ class SemanticIndexUpdateServiceTest extends AbstractTest {
 		String path = "MAIN";
 		List<Concept> concepts = createConcreteValueTestConcepts(path);
 
-		// 396070085 has no data type defined in the MRCM
+		// 396070085 has no data type defined in the MRCM - number data type will default to decimal
 		concepts.add(new Concept("34020007").addRelationship(new Relationship(UUID.randomUUID().toString(), ISA, "34020006"))
 				.addRelationship(new Relationship("3332956025", null, true, "900000000000207008", "34020007",
 						"#10.01", 1, "396070085", "900000000000011006", "900000000000451002")));
-		Exception exception = assertThrows(IllegalStateException.class, () -> {
-			simulateRF2Import(path, concepts);
-		});
-		assertEquals("No MRCM range constraint is defined for concrete attribute 396070085",
-				exception.getMessage());
+		simulateRF2Import(path, concepts);
+
+		assertEquals(1, queryService.search(queryService.createQueryBuilder(false).ecl("<<34020007:* = #10.01"), path, PAGE_REQUEST).getTotalElements());
 	}
 
 	@Test


### PR DESCRIPTION
From ticket:
> We would like to exclude the MRCM refsets from the IPS terminology.
>
> The MRCM refsets are currently required by the ECL index service within Snowstorm to check the data type of the concrete values being indexed.
>
> Try to update the Snowstorm import and ECL index service to work without the MRCM by guessing the data type. All numbers could be indexed as decimals because "=#1" and "=#1.0" are treated the same in ECL anyway.
> 
> This will allow us to exclude the MRCM refsets from the IPS and other future subontologies / terminology products.

This pull request stops the RF2 import from failing when the MRCM is missing. Number concrete domains will default to decimal data type if missing from the MRCM. ECL requests still work as expected as shown in unit tests.