### PR TITLE
Fix #379 Ignore inactive lang member in PT choice.

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/domain/Description.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/domain/Description.java
@@ -216,7 +216,12 @@ public class Description extends SnomedComponent<Description> implements SnomedC
 	}
 
 	public Description addLanguageRefsetMember(String refsetId, String acceptability) {
+		return addLanguageRefsetMember(refsetId, acceptability, true);
+	}
+
+	public Description addLanguageRefsetMember(String refsetId, String acceptability, boolean active) {
 		final ReferenceSetMember member = new ReferenceSetMember(getModuleId(), refsetId, descriptionId);
+		member.setActive(active);
 		member.setAdditionalField(ReferenceSetMember.LanguageFields.ACCEPTABILITY_ID, acceptability);
 		member.setReferencedComponentId(descriptionId);
 		// Replace any existing entry with new set containing just this member
@@ -465,8 +470,7 @@ public class Description extends SnomedComponent<Description> implements SnomedC
 	public boolean hasAcceptability(String acceptability) {
 		for (Set<ReferenceSetMember> members : langRefsetMembersMap.values()) {
 			for (ReferenceSetMember entry : members) {
-				if (entry.isActive()
-						&& acceptability == null || entry.getAdditionalField(ReferenceSetMember.LanguageFields.ACCEPTABILITY_ID).equals(acceptability)) {
+				if (entry.isActive() && (acceptability == null || entry.getAdditionalField(ReferenceSetMember.LanguageFields.ACCEPTABILITY_ID).equals(acceptability))) {
 					return true;
 				}
 			}

--- a/src/test/java/org/snomed/snowstorm/core/util/DescriptionHelperTest.java
+++ b/src/test/java/org/snomed/snowstorm/core/util/DescriptionHelperTest.java
@@ -54,7 +54,16 @@ class DescriptionHelperTest {
 				// I love the history of the English language!
 				new Description("Jet aeroplane").setTypeId(Concepts.SYNONYM).addLanguageRefsetMember(GB_EN_LANG_REFSET, Concepts.PREFERRED),
 
-				new Description("jetfly").setTypeId(Concepts.SYNONYM).setLang("da").addLanguageRefsetMember(danishLanguageReferenceSet, Concepts.PREFERRED)
+				new Description("A1jetfly").setTypeId(Concepts.SYNONYM).setLang("da").addLanguageRefsetMember(danishLanguageReferenceSet, Concepts.PREFERRED, false),
+				new Description("A2jetfly").setTypeId(Concepts.SYNONYM).setLang("da").addLanguageRefsetMember(danishLanguageReferenceSet, Concepts.PREFERRED, false),
+				new Description("A3jetfly").setTypeId(Concepts.SYNONYM).setLang("da").addLanguageRefsetMember(danishLanguageReferenceSet, Concepts.PREFERRED, false),
+				new Description("A4jetfly").setTypeId(Concepts.SYNONYM).setLang("da").addLanguageRefsetMember(danishLanguageReferenceSet, Concepts.PREFERRED, false),
+				new Description("Bjetfly").setTypeId(Concepts.SYNONYM).setLang("da").addLanguageRefsetMember(danishLanguageReferenceSet, Concepts.PREFERRED),
+				new Description("Cjetfly").setTypeId(Concepts.SYNONYM).setLang("da").addLanguageRefsetMember(danishLanguageReferenceSet, Concepts.ACCEPTABLE),
+				new Description("D1jetfly").setTypeId(Concepts.SYNONYM).setLang("da").addLanguageRefsetMember(danishLanguageReferenceSet, Concepts.PREFERRED, false),
+				new Description("D2jetfly").setTypeId(Concepts.SYNONYM).setLang("da").addLanguageRefsetMember(danishLanguageReferenceSet, Concepts.PREFERRED, false),
+				new Description("D3jetfly").setTypeId(Concepts.SYNONYM).setLang("da").addLanguageRefsetMember(danishLanguageReferenceSet, Concepts.PREFERRED, false),
+				new Description("D4jetfly").setTypeId(Concepts.SYNONYM).setLang("da").addLanguageRefsetMember(danishLanguageReferenceSet, Concepts.PREFERRED, false)
 		);
 
 		assertEquals("en-X-900000000000509007,en-X-900000000000508004,en", Config.DEFAULT_ACCEPT_LANG_HEADER);
@@ -63,7 +72,8 @@ class DescriptionHelperTest {
 		assertEquals("Jet aeroplane", getPtTerm("en-X-" + GB_EN_LANG_REFSET, descriptions));
 		assertEquals("Fallback on US english defaults.", "Jet airplane", getPtTerm("en-X-" + danishLanguageReferenceSet, descriptions));
 		assertEquals("Fallback on GB english because of header.", "Jet aeroplane", getPtTerm("en-X-" + danishLanguageReferenceSet + ",en-X-" + GB_EN_LANG_REFSET, descriptions));
-		assertEquals("jetfly", getPtTerm("da-X-" + danishLanguageReferenceSet, descriptions));
+		assertEquals("Bjetfly", getPtTerm("da-X-" + danishLanguageReferenceSet, descriptions));
+		assertEquals("Bjetfly", getPtTerm("da", descriptions));
 	}
 
 	@Test


### PR DESCRIPTION
The issue is that sometimes inactive lang refset members are being used to select previously preferred terms. Parenthesis were missing from the boolean logic in Description. hasAcceptability()