### PR TITLE
default lang refset for lang only accept header

### DIFF
--- a/src/main/java/org/snomed/snowstorm/rest/ControllerHelper.java
+++ b/src/main/java/org/snomed/snowstorm/rest/ControllerHelper.java
@@ -181,6 +181,7 @@ public class ControllerHelper {
 			Matcher matcher = LANGUAGE_PATTERN.matcher(value);
 			if (matcher.matches()) {
 				languageCode = matcher.group(1);
+				// Check if there is a default language reference set for a given language
 				languageReferenceSet = DialectConfigurationService.instance().findRefsetForDialect(value); 
 			} else if ((matcher = LANGUAGE_AND_REFSET_PATTERN.matcher(value)).matches()) {
 				languageCode = matcher.group(1);

--- a/src/main/java/org/snomed/snowstorm/rest/ControllerHelper.java
+++ b/src/main/java/org/snomed/snowstorm/rest/ControllerHelper.java
@@ -181,6 +181,7 @@ public class ControllerHelper {
 			Matcher matcher = LANGUAGE_PATTERN.matcher(value);
 			if (matcher.matches()) {
 				languageCode = matcher.group(1);
+				languageReferenceSet = DialectConfigurationService.instance().findRefsetForDialect(value); 
 			} else if ((matcher = LANGUAGE_AND_REFSET_PATTERN.matcher(value)).matches()) {
 				languageCode = matcher.group(1);
 				languageReferenceSet = parseLong(matcher.group(2));

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -231,6 +231,7 @@ search.dialect.config.no-nb=61000202103
 search.dialect.config.no-nn=91000202106
 search.dialect.config.nb=61000202103
 search.dialect.config.nn=91000202106
+search.dialect.config.sv=46011000052107
 
 
 # ----------------------------------------


### PR DESCRIPTION
When providing just a 2-character language tag with Accept-language (no refset or dialect), the language reference set selected (and the PT provided by snowstorm) becomes slightly random. The PT provided will be any preferred term in any lanugage reference set in the order they are provided.

By adding the default language reference set under "# SNOMED Known Dialects - Individual Configuration" in the application.properties file and adding this default lanugage reference set when a 2-character Accept-language header is given, the assigning of PT becomes predictable.
