### PR TITLE
FRI-210 Preserve International changes after Extension upgrade

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/domain/Concepts.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/domain/Concepts.java
@@ -15,6 +15,7 @@ public class Concepts {
 	public static final String MODEL_MODULE = "900000000000012004";
 	public static final String ICD10_MODULE = "449080006";
 	public static final String COMMON_FRENCH_MODULE = "11000241103";
+	public static final String MODULE = "900000000000443000";
 
 	public static final String PRIMITIVE = "900000000000074008";
 	public static final String FULLY_DEFINED = "900000000000073002";

--- a/src/main/java/org/snomed/snowstorm/core/data/services/BranchReviewService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/BranchReviewService.java
@@ -246,62 +246,37 @@ public class BranchReviewService {
 		upgradedConcept.setDefinitionStatusId(winningConcept.getDefinitionStatusId());
 		upgradedConcept.setInactivationIndicator(winningConcept.getInactivationIndicator());
 		upgradedConcept.setAssociationTargets(winningConcept.getAssociationTargets());
-		upgradedConcept.setDescriptions(mergePublishedDescriptions(sourceVersion.getDescriptions(), targetVersion.getDescriptions()));
-		upgradedConcept.setRelationships(mergePublishedRelationships(sourceVersion.getRelationships(), targetVersion.getRelationships()));
+		upgradedConcept.setDescriptions(mergePublished(sourceVersion.getDescriptions(), targetVersion.getDescriptions()));
+		upgradedConcept.setRelationships(mergePublished(sourceVersion.getRelationships(), targetVersion.getRelationships()));
 		upgradedConcept.setClassAxioms(mergePublishedAxioms(sourceVersion.getClassAxioms(), targetVersion.getClassAxioms()));
 		upgradedConcept.setGciAxioms(mergePublishedAxioms(sourceVersion.getGciAxioms(), sourceVersion.getGciAxioms()));
 
 		return upgradedConcept;
 	}
 
-	private Set<Description> mergePublishedDescriptions(Set<Description> sourceDescriptions, Set<Description> targetDescriptions) {
-		Map<String, Description> mergedDescriptions = new HashMap<>();
+	private <T extends SnomedComponent> Set<T> mergePublished(Set<T> sourceComponents, Set<T> targetComponents) {
+		Map<String, T> mergedComponents = new HashMap<>();
 
-		for (Description sourceDescription : sourceDescriptions) {
-			boolean publishedAndUnchanged = sourceDescription.getReleasedEffectiveTime() != null && sourceDescription.getEffectiveTimeI() != null;
+		for (T sourceComponent : sourceComponents) {
+			boolean publishedAndUnchanged = sourceComponent.getReleasedEffectiveTime() != null && sourceComponent.getEffectiveTimeI() != null;
 			if (publishedAndUnchanged) {
-				mergedDescriptions.put(sourceDescription.getId(), sourceDescription);
+				mergedComponents.put(sourceComponent.getId(), sourceComponent);
 			}
 		}
 
-		for (Description targetDescription : targetDescriptions) {
-			String targetDescriptionId = targetDescription.getId();
-			Description sourceDescription = mergedDescriptions.get(targetDescriptionId);
+		for (T targetComponent : targetComponents) {
+			String targetDescriptionId = targetComponent.getId();
+			T sourceComponent = mergedComponents.get(targetDescriptionId);
 
-			if (sourceDescription == null) {
-				mergedDescriptions.put(targetDescriptionId, targetDescription);
-			} else if (!sourceDescription.isReleasedMoreRecentlyThan(targetDescription)) {
-				mergedDescriptions.put(targetDescriptionId, targetDescription);
+			if (sourceComponent == null) {
+				mergedComponents.put(targetDescriptionId, targetComponent);
+			} else if (!sourceComponent.isReleasedMoreRecentlyThan(targetComponent)) {
+				mergedComponents.put(targetDescriptionId, targetComponent);
 			}
 		}
 
-		return new HashSet<>(mergedDescriptions.values());
+		return new HashSet<>(mergedComponents.values());
 	}
-
-	private Set<Relationship> mergePublishedRelationships(Set<Relationship> sourceRelationships, Set<Relationship> targetRelationships) {
-		Map<String, Relationship> mergedRelationships = new HashMap<>();
-
-		for (Relationship sourceRelationship : sourceRelationships) {
-			boolean publishedAndUnchanged = sourceRelationship.getReleasedEffectiveTime() != null && sourceRelationship.getEffectiveTimeI() != null;
-			if (publishedAndUnchanged) {
-				mergedRelationships.put(sourceRelationship.getId(), sourceRelationship);
-			}
-		}
-
-		for (Relationship targetRelationship : targetRelationships) {
-			String targetComponentId = targetRelationship.getId();
-			Relationship sourceRelationship = mergedRelationships.get(targetComponentId);
-
-			if (sourceRelationship == null) {
-				mergedRelationships.put(targetComponentId, targetRelationship);
-			} else if (!sourceRelationship.isReleasedMoreRecentlyThan(targetRelationship)) {
-				mergedRelationships.put(targetComponentId, targetRelationship);
-			}
-		}
-
-		return new HashSet<>(mergedRelationships.values());
-	}
-
 
 	private Set<Axiom> mergePublishedAxioms(Set<Axiom> sourceAxioms, Set<Axiom> targetAxioms) {
 		Map<String, Axiom> mergedAxioms = new HashMap<>();

--- a/src/main/java/org/snomed/snowstorm/core/data/services/BranchReviewService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/BranchReviewService.java
@@ -361,24 +361,24 @@ public class BranchReviewService {
 		return mergedConcept;
 	}
 
-	private <T extends IdAndEffectiveTimeComponent> Set<T> mergeComponentSets(Set<T> sourceDescriptions, Set<T> targetDescriptions) {
-		final Set<T> mergedDescriptions = new HashSet<>(sourceDescriptions);
-		for (final T targetDescription : targetDescriptions) {
-			if (targetDescription.getEffectiveTimeI() == null) {
-				if (mergedDescriptions.contains(targetDescription)) {
-					Optional<T> sourceDescription = mergedDescriptions.stream()
-							.filter(otherDescription -> otherDescription.getId().equals(targetDescription.getId())).findFirst();
-					if (sourceDescription.isPresent() && sourceDescription.get().getEffectiveTimeI() != null) {
-						// Only target description is unpublished, replace.
-						mergedDescriptions.add(targetDescription);
+	private <T extends IdAndEffectiveTimeComponent> Set<T> mergeComponentSets(Set<T> sourceComponents, Set<T> targetComponents) {
+		final Set<T> mergedComponents = new HashSet<>(sourceComponents);
+		for (final T targetComponent : targetComponents) {
+			if (targetComponent.getEffectiveTimeI() == null) {
+				if (mergedComponents.contains(targetComponent)) {
+					Optional<T> sourceComponent = mergedComponents.stream()
+							.filter(otherComponent -> otherComponent.getId().equals(targetComponent.getId())).findFirst();
+					if (sourceComponent.isPresent() && sourceComponent.get().getEffectiveTimeI() != null) {
+						// Only target component is unpublished, replace.
+						mergedComponents.add(targetComponent);
 					}
 				} else {
-					// Target description is new and not yet promoted to source.
-					mergedDescriptions.add(targetDescription);
+					// Target component is new and not yet promoted to source.
+					mergedComponents.add(targetComponent);
 				}
 			}
 		}
-		return mergedDescriptions;
+		return mergedComponents;
 	}
 
 	public BranchReview getCreateReview(String source, String target) {

--- a/src/main/java/org/snomed/snowstorm/core/data/services/BranchReviewService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/BranchReviewService.java
@@ -257,6 +257,7 @@ public class BranchReviewService {
 	private <T extends SnomedComponent> Set<T> mergePublished(Set<T> sourceComponents, Set<T> targetComponents) {
 		Map<String, T> mergedComponents = new HashMap<>();
 		for (T sourceComponent : sourceComponents) {
+			// published and no further changes
 			if (sourceComponent.getEffectiveTimeI() != null) {
 				mergedComponents.put(sourceComponent.getId(), sourceComponent);
 			}
@@ -266,16 +267,11 @@ public class BranchReviewService {
 			String targetComponentId = targetComponent.getId();
 			if (mergedComponents.containsKey(targetComponentId)) {
 				T sourceComponent = mergedComponents.get(targetComponentId);
-				if (sourceComponent.isReleasedMoreRecentlyThan(targetComponent)) {
-					// target component is an old version
-					if (targetComponent.getEffectiveTimeI() != null) {
-						mergedComponents.put(targetComponentId, sourceComponent);
-					} else {
-						// target version with change but need to update old release details
-						targetComponent.setReleasedEffectiveTime(sourceComponent.getReleasedEffectiveTime());
-						targetComponent.setReleaseHash(sourceComponent.getReleaseHash());
-						mergedComponents.put(targetComponentId, targetComponent);
-					}
+				if (targetComponent.getEffectiveTimeI() == null) {
+					// target version with change but need to update old release details
+					targetComponent.setReleasedEffectiveTime(sourceComponent.getReleasedEffectiveTime());
+					targetComponent.setReleaseHash(sourceComponent.getReleaseHash());
+					mergedComponents.put(targetComponentId, targetComponent);
 				}
 			} else {
 				// component only exists in target

--- a/src/main/java/org/snomed/snowstorm/core/data/services/ConceptUpdateHelper.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/ConceptUpdateHelper.java
@@ -606,7 +606,7 @@ public class ConceptUpdateHelper extends ComponentService {
 			
 			
 			//Any change to a component in an extension needs to be done in the default module
-			if (newComponent.isChanged() && (defaultModuleId != null && 
+			if (newComponent.isComponentChanged(existingComponent) && (defaultModuleId != null &&
 					!defaultModuleId.equals(Concepts.CORE_MODULE))) {
 				newComponent.setModuleId(defaultModuleId);
 			}

--- a/src/test/java/org/snomed/snowstorm/core/data/services/BranchMergeServiceTest.java
+++ b/src/test/java/org/snomed/snowstorm/core/data/services/BranchMergeServiceTest.java
@@ -3118,6 +3118,462 @@ class BranchMergeServiceTest extends AbstractTest {
 		assertFalse(description.isReleased());
 	}
 
+	@Test
+	void testPropertiesWhenRebasingDifferentScenarios() throws ServiceException, InterruptedException {
+		/*
+		 * Concept has been released.
+		 * Concept has been updated & released.
+		 * Task was created before the second release,
+		 * and has no subsequent changes.
+		 * Assert properties after rebasing and selecting
+		 * L/M/R columns within the merge.
+		 * */
+		String year = "2022";
+		assertReleaseProperties(year + "0131",
+				year + "0331",
+				year + "0331",
+				year + "0131",
+				year + "0131",
+				"left",
+				year + "0331",
+				year + "0331"
+		);
+
+		year = "2023";
+		assertReleaseProperties(year + "0131",
+				year + "0331",
+				year + "0331",
+				year + "0131",
+				year + "0131",
+				"middle",
+				year + "0331",
+				year + "0331"
+		);
+
+		year = "2024";
+		assertReleaseProperties(year + "0131",
+				year + "0331",
+				year + "0331",
+				year + "0131",
+				year + "0131",
+				"right",
+				year + "0331",
+				year + "0331"
+		);
+
+		/*
+		 * Concept has been released.
+		 * Concept has been updated & released.
+		 * Task was created before the second release,
+		 * but has subsequent changes.
+		 * Assert properties after rebasing and selecting
+		 * L/M/R columns within the merge.
+		 * */
+		year = "2025";
+		assertReleaseProperties(year + "0131",
+				year + "0331",
+				year + "0331",
+				year + "0131",
+				null,
+				"left",
+				year + "0331",
+				year + "0331"
+		);
+
+		year = "2026";
+		assertReleaseProperties(year + "0131",
+				year + "0331",
+				year + "0331",
+				year + "0331",
+				null,
+				"middle",
+				year + "0331",
+				null
+		);
+
+		year = "2027";
+		assertReleaseProperties(year + "0131",
+				year + "0331",
+				year + "0331",
+				year + "0331",
+				null,
+				"right",
+				year + "0331",
+				null
+		);
+
+		/*
+		 * Concept has been released.
+		 * Concept has been updated & released.
+		 * Task was created after the second release, but
+		 * has subsequent changes.
+		 * Assert properties after rebasing and selecting
+		 * L/M/R columns within the merge.
+		 * */
+		year = "2028";
+		assertReleaseProperties(year + "0131",
+				year + "0331",
+				year + "0331",
+				year + "0331",
+				null,
+				null,
+				year + "0331",
+				null
+		);
+
+		year = "2029";
+		assertReleaseProperties(year + "0131",
+				year + "0331",
+				year + "0331",
+				year + "0331",
+				null,
+				"left",
+				year + "0331",
+				year + "0331"
+		);
+
+		year = "2030";
+		assertReleaseProperties(year + "0131",
+				year + "0331",
+				year + "0331",
+				year + "0331",
+				null,
+				"middle",
+				year + "0331",
+				null
+		);
+
+		year = "2031";
+		assertReleaseProperties(year + "0131",
+				year + "0331",
+				year + "0331",
+				year + "0331",
+				null,
+				"right",
+				year + "0331",
+				null
+		);
+
+		/*
+		 * Concept has been released.
+		 * Concept has been updated & released.
+		 * Task was created before the second release, and has had
+		 * no subsequent changes.
+		 * Assert properties after rebasing and selecting
+		 * L/M/R columns within the merge.
+		 * */
+		year = "2032";
+		assertReleaseProperties(year + "0131",
+				year + "0331",
+				null,
+				year + "0131",
+				year + "0131",
+				"left",
+				year + "0331",
+				null
+		);
+
+		year = "2033";
+		assertReleaseProperties(year + "0131",
+				year + "0331",
+				null,
+				year + "0131",
+				year + "0131",
+				"middle",
+				year + "0331",
+				null
+		);
+
+		year = "2034";
+		assertReleaseProperties(year + "0131",
+				year + "0331",
+				null,
+				year + "0131",
+				year + "0131",
+				"right",
+				year + "0331",
+				null
+		);
+
+		/*
+		 * Concept has been released.
+		 * Concept has been updated and released, and has subsequent changes.
+		 * Task was created before the second release, and has also had
+		 * subsequent changes.
+		 * Assert properties after rebasing and selecting L/M/R columns within the merge.
+		 * */
+		year = "2035";
+		assertReleaseProperties(year + "0131",
+				year + "0331",
+				null,
+				year + "0131",
+				null,
+				"left",
+				year + "0331",
+				null
+		);
+
+		year = "2036";
+		assertReleaseProperties(year + "0131",
+				year + "0331",
+				null,
+				year + "0131",
+				null,
+				"middle",
+				year + "0331",
+				null
+		);
+
+		year = "2037";
+		assertReleaseProperties(year + "0131",
+				year + "0331",
+				null,
+				year + "0131",
+				null,
+				"right",
+				year + "0331",
+				null
+		);
+
+		/*
+		 * Concept has been released.
+		 * Concept has been updated and released, and has subsequent changes.
+		 * Task was created before the first release and has null release properties.
+		 * Assert properties after rebasing and selecting L/M/R columns within the merge.
+		 * */
+		year = "2038";
+		assertReleaseProperties(year + "0131",
+				year + "0331",
+				null,
+				null,
+				null,
+				"left",
+				year + "0331",
+				null
+		);
+
+		year = "2039";
+		assertReleaseProperties(year + "0131",
+				year + "0331",
+				null,
+				null,
+				null,
+				"middle",
+				year + "0331",
+				null
+		);
+
+		year = "2040";
+		assertReleaseProperties(year + "0131",
+				year + "0331",
+				null,
+				null,
+				null,
+				"right",
+				year + "0331",
+				null
+		);
+
+		/*
+		 * Concept has not been released and has null release properties
+		 * on both project and task.
+		 * Assert properties after rebasing and selecting L/M/R columns within the merge.
+		 * */
+		assertReleaseProperties(null,
+				null,
+				null,
+				null,
+				null,
+				"left",
+				null,
+				null
+		);
+
+		assertReleaseProperties(null,
+				null,
+				null,
+				null,
+				null,
+				"middle",
+				null,
+				null
+		);
+
+		assertReleaseProperties(null,
+				null,
+				null,
+				null,
+				null,
+				"right",
+				null,
+				null
+		);
+	}
+
+	void assertReleaseProperties(
+			String initialReleaseEffectiveTime,
+			String projectReleaseEffectiveTime,
+			String projectEffectiveTime,
+			String taskReleaseEffectiveTime,
+			String taskEffectiveTime,
+			String column,
+			String finalReleaseEffectiveTime,
+			String finalEffectiveTime
+	) throws ServiceException, InterruptedException {
+		Map<String, String> intPreferred = Map.of(US_EN_LANG_REFSET, descriptionAcceptabilityNames.get(PREFERRED), GB_EN_LANG_REFSET, descriptionAcceptabilityNames.get(PREFERRED));
+		Map<String, String> intAcceptable = Map.of(US_EN_LANG_REFSET, descriptionAcceptabilityNames.get(PREFERRED), GB_EN_LANG_REFSET, descriptionAcceptabilityNames.get(ACCEPTABLE));
+		String ci = "CASE_INSENSITIVE";
+		Concept concept;
+		CodeSystem codeSystem;
+		MergeReview review;
+		Collection<MergeReviewConceptVersions> conflicts;
+
+		// International project
+		String project = "MAIN/" + UUID.randomUUID().toString().substring(0, 5);
+		branchService.create(project);
+
+		// International task (Created before / after versioning depending on scenario)
+		String task = project + "/" + UUID.randomUUID().toString().substring(0, 5);
+
+		// Create Concept
+		concept = new Concept()
+				.addDescription(new Description("Cinnamon bun (food)").setTypeId(FSN).setCaseSignificance(ci).setAcceptabilityMap(intPreferred))
+				.addDescription(new Description("Cinnamon bun").setTypeId(SYNONYM).setCaseSignificance(ci).setAcceptabilityMap(intPreferred))
+				.addDescription(new Description("Cinnamon roll").setTypeId(SYNONYM).setCaseSignificance(ci).setAcceptabilityMap(intAcceptable))
+				.addAxiom(new Relationship(ISA, SNOMEDCT_ROOT));
+		concept = conceptService.create(concept, project);
+		String cinnamonId = concept.getConceptId();
+
+		// Promote Project to Main
+		concept = conceptService.find(cinnamonId, "MAIN");
+		assertNull(concept);
+		branchMergeService.mergeBranchSync(project, "MAIN", Collections.emptySet());
+		concept = conceptService.find(cinnamonId, "MAIN");
+		assertNotNull(concept);
+
+		// Task created before International versioning
+		if (taskReleaseEffectiveTime == null && taskEffectiveTime == null) {
+			branchService.create(task);
+		}
+
+		// Version International
+		if (initialReleaseEffectiveTime != null) {
+			// Version
+			codeSystem = codeSystemService.find("SNOMEDCT");
+			codeSystemService.createVersion(codeSystem, Integer.parseInt(initialReleaseEffectiveTime), initialReleaseEffectiveTime);
+
+			// Rebase project
+			review = getMergeReviewInCurrentState("MAIN", project);
+			conflicts = reviewService.getMergeReviewConflictingConcepts(review.getId(), new ArrayList<>());
+			assertEquals(0, conflicts.size());
+
+			reviewService.applyMergeReview(review);
+		}
+
+		// Update International Concept (publish)
+		if (projectReleaseEffectiveTime != null && !projectReleaseEffectiveTime.equals(initialReleaseEffectiveTime)) {
+			// Change Concept module
+			concept = conceptService.find(cinnamonId, project);
+			concept.setModuleId(MODEL_MODULE);
+			conceptService.update(concept, project);
+
+			// Promote project to main
+			branchMergeService.mergeBranchSync(project, "MAIN", Collections.emptySet());
+
+			// Version International
+			codeSystem = codeSystemService.find("SNOMEDCT");
+			codeSystemService.createVersion(codeSystem, Integer.parseInt(projectReleaseEffectiveTime), projectReleaseEffectiveTime);
+
+			// Rebase project
+			review = getMergeReviewInCurrentState("MAIN", project);
+			conflicts = reviewService.getMergeReviewConflictingConcepts(review.getId(), new ArrayList<>());
+			assertEquals(0, conflicts.size());
+
+			reviewService.applyMergeReview(review);
+		}
+
+		// Task has latest version
+		if (taskReleaseEffectiveTime != null && taskReleaseEffectiveTime.equals(projectReleaseEffectiveTime)) {
+			branchService.create(task);
+		}
+
+		// Update Concept on project (do not publish)
+		if (projectEffectiveTime == null) {
+			// Change Concept
+			concept = conceptService.find(cinnamonId, project);
+			concept.setModuleId(CORE_MODULE);
+			conceptService.update(concept, project);
+
+			// Promote project to main
+			branchMergeService.mergeBranchSync(project, "MAIN", Collections.emptySet());
+		}
+
+		// Task is behind a version
+		if (taskReleaseEffectiveTime != null && !taskReleaseEffectiveTime.equals(projectReleaseEffectiveTime)) {
+			branchService.create(task);
+		}
+
+		// Update Concept on task (do not publish)
+		if (taskEffectiveTime == null) {
+			// Change Concept
+			concept = conceptService.find(cinnamonId, task);
+			concept.setDefinitionStatusId(FULLY_DEFINED);
+			conceptService.update(concept, task);
+		}
+
+		// Update Concept on project (to allow task to rebase)
+		if (column != null) {
+			concept = conceptService.find(cinnamonId, project);
+			concept.addDescription(new Description("Cinnamon swirls").setTypeId(SYNONYM).setCaseSignificance(ci).setAcceptabilityMap(intAcceptable));
+			conceptService.update(concept, project);
+		}
+
+		// Rebase task
+		review = getMergeReviewInCurrentState(project, task);
+		conflicts = reviewService.getMergeReviewConflictingConcepts(review.getId(), new ArrayList<>());
+		if (column == null) {
+			assertEquals(0, conflicts.size());
+		} else {
+			if ((taskReleaseEffectiveTime != null && taskReleaseEffectiveTime.equals(projectReleaseEffectiveTime))) {
+				assertTrue(conflicts.size() != 0);
+			}
+
+			for (MergeReviewConceptVersions conflict : conflicts) {
+				Concept conceptToAccept = conflict.getSourceConcept();
+
+				column = column.toLowerCase();
+				if ("middle".equals(column)) {
+					conceptToAccept = conflict.getAutoMergedConcept();
+				} else if ("right".equals(column)) {
+					conceptToAccept = conflict.getTargetConcept();
+				}
+
+				reviewService.persistManuallyMergedConcept(review, Long.parseLong(cinnamonId), conceptToAccept);
+			}
+
+			reviewService.applyMergeReview(review);
+		}
+
+		// Assert state of task
+		concept = conceptService.find(cinnamonId, task);
+
+		Integer fRET;
+		if (finalReleaseEffectiveTime != null) {
+			fRET = Integer.parseInt(finalReleaseEffectiveTime);
+			assertEquals(fRET, concept.getReleasedEffectiveTime());
+		} else {
+			assertNull(concept.getReleasedEffectiveTime());
+		}
+
+		Integer fET;
+		if (finalEffectiveTime != null) {
+			fET = Integer.parseInt(finalEffectiveTime);
+			assertEquals(fET, concept.getEffectiveTimeI());
+		} else {
+			assertNull(concept.getEffectiveTimeI());
+		}
+	}
+
 	private void assertNotVersioned(Description description) {
 		assertNull(description.getEffectiveTime());
 		assertFalse(description.isReleased());


### PR DESCRIPTION
FRI-210 is concerned with preventing International changes being lost whenever an Extension does an upgrade/a rebase. 