### PR TITLE
Endpoint to trigger scheduled dailybuild import

### DIFF
--- a/src/main/java/org/snomed/snowstorm/dailybuild/DailyBuildService.java
+++ b/src/main/java/org/snomed/snowstorm/dailybuild/DailyBuildService.java
@@ -86,6 +86,13 @@ public class DailyBuildService {
 		SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
 		return latestDailyBuild.equals(formatter.format(new Date()));
 	}
+	public void triggerScheduledImport(CodeSystem codeSystem) {
+		try {
+			performScheduledImport(codeSystem);
+		} catch (Exception e) {
+			logger.error("Failed to import daily build for code system {}", codeSystem.getShortName(), e);
+		}
+	}
 
 	void performScheduledImport(CodeSystem codeSystem) throws IOException, ReleaseImportException {
 		String branchPath = codeSystem.getBranchPath();

--- a/src/main/java/org/snomed/snowstorm/rest/CodeSystemController.java
+++ b/src/main/java/org/snomed/snowstorm/rest/CodeSystemController.java
@@ -198,6 +198,15 @@ public class CodeSystemController {
 		dailyBuildService.rollbackDailyBuildContent(codeSystem);
 	}
 
+	@ApiOperation(value = "Trigger scheduled daily build import.",
+		notes = "The daily build import is scheduled to perform at a configured time interval per default." + 
+				"This operation manually triggers the scheduled daily build import service to perform.")
+	@RequestMapping(value = "/{shortName}/daily-build/import", method = RequestMethod.POST)
+	public void triggerScheduledImport(@PathVariable String shortName) {
+			CodeSystem codeSystem = codeSystemService.find(shortName);
+			dailyBuildService.triggerScheduledImport(codeSystem);
+	}
+
 	@ApiOperation(value = "Generate additional english language refset",
 			notes = "Before running this extensions must be upgraded already. " +
 					"You must specify the branch path(e.g MAIN/SNOMEDCT-NZ/{project}/{task}) of the task for the delta to be added. " +


### PR DESCRIPTION
endpoint makes it easier for us to test, debug and/or reactivate DB after a rollback, an upgrade or similar situation where I want to remove the DB and not have to wait X minutes or change the config file and restart the app twice.