### PR TITLE
MAINT-1974 Added configurable branch to refset types

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/services/ReferenceSetMemberService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/ReferenceSetMemberService.java
@@ -34,6 +34,7 @@ import org.snomed.snowstorm.core.util.PageHelper;
 import org.snomed.snowstorm.ecl.ECLQueryService;
 import org.snomed.snowstorm.rest.converter.SearchAfterHelper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -100,6 +101,9 @@ public class ReferenceSetMemberService extends ComponentService {
 
 	@Autowired
 	private ECLQueryService eclQueryService;
+
+	@Value("${types.branch}")
+	private String refsetsBranchPath;
 
 	private final Cache<String, AsyncRefsetMemberChangeBatch> batchChanges = CacheBuilder.newBuilder().expireAfterWrite(2, TimeUnit.HOURS).build();
 
@@ -466,10 +470,11 @@ public class ReferenceSetMemberService extends ComponentService {
 	}
 
 	private void setupTypes(Set<ReferenceSetType> referenceSetTypes) {
-		String path = MAIN;
-		if (!branchService.exists(path)) {
-			sBranchService.create(path);
+		String path = refsetsBranchPath.toUpperCase();
+		if (!branchService.exists(MAIN)) {
+			sBranchService.create(MAIN);
 		}
+		logger.info("Reference set types are configured against branch: '{}'.", path);
 		List<ReferenceSetType> existingTypes = findConfiguredReferenceSetTypes(path);
 		Set<ReferenceSetType> typesToRemove = new HashSet<>(existingTypes);
 		typesToRemove.removeAll(referenceSetTypes);

--- a/src/main/java/org/snomed/snowstorm/core/data/services/ReferenceSetMemberService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/ReferenceSetMemberService.java
@@ -102,7 +102,7 @@ public class ReferenceSetMemberService extends ComponentService {
 	@Autowired
 	private ECLQueryService eclQueryService;
 
-	@Value("${refset-types.initial-branch:MAIN}")
+	@Value("${refset-types.initial-branch}")
 	private String refsetsBranchPath;
 
 	private final Cache<String, AsyncRefsetMemberChangeBatch> batchChanges = CacheBuilder.newBuilder().expireAfterWrite(2, TimeUnit.HOURS).build();

--- a/src/main/java/org/snomed/snowstorm/core/data/services/ReferenceSetMemberService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/ReferenceSetMemberService.java
@@ -102,8 +102,8 @@ public class ReferenceSetMemberService extends ComponentService {
 	@Autowired
 	private ECLQueryService eclQueryService;
 
-	@Value("${refsets.branch:MAIN}")
-		private String refsetsBranchPath;
+	@Value("${refset-types.initial-branch:MAIN}")
+	private String refsetsBranchPath;
 
 	private final Cache<String, AsyncRefsetMemberChangeBatch> batchChanges = CacheBuilder.newBuilder().expireAfterWrite(2, TimeUnit.HOURS).build();
 
@@ -470,7 +470,7 @@ public class ReferenceSetMemberService extends ComponentService {
 	}
 
 	private void setupTypes(Set<ReferenceSetType> referenceSetTypes) {
-		String path = refsetsBranchPath.toUpperCase();
+		String path = refsetsBranchPath;
 		if (!branchService.exists(MAIN)) {
 			sBranchService.create(MAIN);
 		}

--- a/src/main/java/org/snomed/snowstorm/core/data/services/ReferenceSetMemberService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/ReferenceSetMemberService.java
@@ -102,8 +102,8 @@ public class ReferenceSetMemberService extends ComponentService {
 	@Autowired
 	private ECLQueryService eclQueryService;
 
-	@Value("${types.branch}")
-	private String refsetsBranchPath;
+	@Value("${refsets.branch:MAIN}")
+		private String refsetsBranchPath;
 
 	private final Cache<String, AsyncRefsetMemberChangeBatch> batchChanges = CacheBuilder.newBuilder().expireAfterWrite(2, TimeUnit.HOURS).build();
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -154,7 +154,7 @@ cache.ecl.enabled=true
 #   During import files are matched using pattern ".*_{FieldNames}Refset_{Name}.*".
 #   For more information see the 'Release File Specification' section of the Technical Implementation Guide http://snomed.org/tig
 # ----------------------------------------
-#refsets.branch=MAIN
+refset-types.initial-branch=MAIN
 refset.types.OWLExpression=762676003|/Terminology|s|owlExpression
 refset.types.Language=900000000000506000|Language|c|acceptabilityId
 refset.types.AssociationReference=900000000000521006|Content|c|targetComponentId

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -149,7 +149,8 @@ cache.ecl.enabled=true
 #         These form part of the exported filename.
 #     {FieldNames} is a comma separated list of the field names after the 'referencedComponentId' field.
 #
-#   New refset types are per default on the MAIN branch but can be configured to any already existing branch.  
+#   New refset types are per default on the MAIN branch but can be configured to any already existing branch. 
+#   Refset types are configured on an initial branch but can be rebased to a child branch. 
 #
 #   During import files are matched using pattern ".*_{FieldNames}Refset_{Name}.*".
 #   For more information see the 'Release File Specification' section of the Technical Implementation Guide http://snomed.org/tig

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -149,9 +149,12 @@ cache.ecl.enabled=true
 #         These form part of the exported filename.
 #     {FieldNames} is a comma separated list of the field names after the 'referencedComponentId' field.
 #
+#   New refset types are per default on the MAIN branch but can be configured to any already existing branch.  
+#
 #   During import files are matched using pattern ".*_{FieldNames}Refset_{Name}.*".
 #   For more information see the 'Release File Specification' section of the Technical Implementation Guide http://snomed.org/tig
 # ----------------------------------------
+#refsets.branch=MAIN
 refset.types.OWLExpression=762676003|/Terminology|s|owlExpression
 refset.types.Language=900000000000506000|Language|c|acceptabilityId
 refset.types.AssociationReference=900000000000521006|Content|c|targetComponentId


### PR DESCRIPTION
Added a config option for setting up reference set types on other branches than MAIN, which was hardcoded before.

Thought of loading all available branches during app init and config all refset types to all there and then, but this should be good enough for our needs. 

`"refsets.branch"` defaults to MAIN if it's unset in application.properties. If configured branch don't exist exception is thrown (`java.lang.IllegalArgumentException: Branch 'BLABLA' does not exist.`) and app fails to start. 