### PR TITLE
ISTO-42 Fix ECL caching bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 		<dependency>
 			<groupId>org.snomed.languages</groupId>
 			<artifactId>snomed-ecl-parser</artifactId>
-			<version>2.0.0</version>
+			<version>2.0.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.snomed.languages</groupId>

--- a/src/main/java/org/snomed/snowstorm/ecl/BranchVersionECLCache.java
+++ b/src/main/java/org/snomed/snowstorm/ecl/BranchVersionECLCache.java
@@ -31,7 +31,9 @@ public class BranchVersionECLCache {
 	}
 
 	public Page<Long> get(String ecl, boolean stated, PageRequest pageRequest) {
-		return eclToConceptsCache.get(new ECLCacheEntry(ecl, stated, pageRequest));
+		ECLCacheEntry key = new ECLCacheEntry(ecl, stated, pageRequest);
+		Page<Long> longs = eclToConceptsCache.get(key);
+		return longs;
 	}
 
 	public void put(String ecl, boolean stated, PageRequest pageRequest, Page<Long> page) {

--- a/src/main/java/org/snomed/snowstorm/ecl/ECLContentService.java
+++ b/src/main/java/org/snomed/snowstorm/ecl/ECLContentService.java
@@ -325,7 +325,7 @@ public class ECLContentService {
 	private void applyEffectiveTimeFilters(List<EffectiveTimeFilter> effectiveTimeFilters, BoolQueryBuilder componentFilterQuery) {
 		for (EffectiveTimeFilter effectiveTimeFilter : orEmpty(effectiveTimeFilters)) {
 			NumericComparisonOperator operator = effectiveTimeFilter.getOperator();
-			Set<Integer> effectiveTimes = effectiveTimeFilter.getEffectiveTime();
+			List<Integer> effectiveTimes = effectiveTimeFilter.getEffectiveTime();
 			BoolQueryBuilder query = boolQuery();
 			String effectiveTimeField = SnomedComponent.Fields.EFFECTIVE_TIME;
 			addNumericConstraint(operator, effectiveTimeField, effectiveTimes, query);

--- a/src/main/java/org/snomed/snowstorm/ecl/SECLObjectFactory.java
+++ b/src/main/java/org/snomed/snowstorm/ecl/SECLObjectFactory.java
@@ -15,7 +15,7 @@ import org.snomed.snowstorm.ecl.domain.expressionconstraint.SSubExpressionConstr
 import org.snomed.snowstorm.ecl.domain.filter.*;
 import org.snomed.snowstorm.ecl.domain.refinement.*;
 
-import java.util.Set;
+import java.util.List;
 
 public class SECLObjectFactory extends ECLObjectFactory {
 
@@ -80,7 +80,7 @@ public class SECLObjectFactory extends ECLObjectFactory {
 	}
 
 	@Override
-	public EffectiveTimeFilter getEffectiveTimeFilter(NumericComparisonOperator operator, Set<Integer> effectiveTimes) {
+	public EffectiveTimeFilter getEffectiveTimeFilter(NumericComparisonOperator operator, List<Integer> effectiveTimes) {
 		return new SEffectiveTimeFilter(operator, effectiveTimes);
 	}
 

--- a/src/main/java/org/snomed/snowstorm/ecl/domain/expressionconstraint/SSubExpressionConstraint.java
+++ b/src/main/java/org/snomed/snowstorm/ecl/domain/expressionconstraint/SSubExpressionConstraint.java
@@ -357,6 +357,23 @@ public class SSubExpressionConstraint extends SubExpressionConstraint implements
 	public StringBuffer toString(StringBuffer buffer) {
 		if (operator != null) {
 			buffer.append(operator.getText()).append(" ");
+			if (operator == Operator.memberOf) {
+				boolean returnAllMemberFields = isReturnAllMemberFields();
+				List<String> memberFieldsToReturn = getMemberFieldsToReturn();
+				if (returnAllMemberFields) {
+					buffer.append("[*] ");
+				} else if (memberFieldsToReturn != null && !memberFieldsToReturn.isEmpty()) {
+					buffer.append("[");
+					int a = 0;
+					for (String field : memberFieldsToReturn) {
+						if (a++ > 0) {
+							buffer.append(", ");
+						}
+						buffer.append(field);
+					}
+					buffer.append("] ");
+				}
+			}
 		}
 		if (conceptId != null) {
 			buffer.append(conceptId);

--- a/src/main/java/org/snomed/snowstorm/ecl/domain/filter/ECLToStringUtil.java
+++ b/src/main/java/org/snomed/snowstorm/ecl/domain/filter/ECLToStringUtil.java
@@ -22,23 +22,28 @@ public class ECLToStringUtil {
 
 	public static void toString(StringBuffer buffer, List<ConceptReference> conceptReferences) {
 		if (conceptReferences != null) {
+			buffer.append(" ");
 			if (conceptReferences.size() > 1) {
-				buffer.append(" (");
+				buffer.append("(");
 			}
+			int i = 0;
 			for (ConceptReference conceptReference : conceptReferences) {
-				buffer.append(" ");
+				if (i++ > 0) {
+					buffer.append(" ");
+				}
 				toString(buffer, conceptReference);
 			}
 			if (conceptReferences.size() > 1) {
-				buffer.append(" )");
+				buffer.append(")");
 			}
 		}
 	}
 
 	public static void toStringTypedSearchTerms(StringBuffer buffer, List<TypedSearchTerm> typedSearchTermSet) {
 		if (typedSearchTermSet != null) {
+			buffer.append(" ");
 			if (typedSearchTermSet.size() > 1) {
-				buffer.append(" (");
+				buffer.append("(");
 			}
 			boolean anyWildcards = typedSearchTermSet.stream().anyMatch(term -> term.getType() == SearchType.WILDCARD);
 			int i = 0;
@@ -50,13 +55,13 @@ public class ECLToStringUtil {
 					if (typedSearchTerm.getType() == SearchType.MATCH) {
 						buffer.append("match:");
 					} else {
-						buffer.append("wildcard:");
+						buffer.append("wild:");
 					}
 				}
 				buffer.append("\"").append(typedSearchTerm.getTerm()).append("\"");
 			}
 			if (typedSearchTermSet.size() > 1) {
-				buffer.append(" )");
+				buffer.append(")");
 			}
 		}
 	}
@@ -68,16 +73,21 @@ public class ECLToStringUtil {
 		}
 	}
 
-	public static void toString(StringBuffer buffer, Collection<Integer> values) {
-		if (values != null) {
-			if (values.size() > 1) {
-				buffer.append(" (");
+	public static void toString(StringBuffer buffer, Collection<Integer> effectiveTimeValues) {
+		if (effectiveTimeValues != null) {
+			buffer.append(" ");
+			if (effectiveTimeValues.size() > 1) {
+				buffer.append("(");
 			}
-			for (Integer value : values) {
-				buffer.append(" ").append(value);
+			int i = 0;
+			for (Integer value : effectiveTimeValues) {
+				if (i++ > 0) {
+					buffer.append(" ");
+				}
+				buffer.append("\"").append(value).append("\"");
 			}
-			if (values.size() > 1) {
-				buffer.append(" )");
+			if (effectiveTimeValues.size() > 1) {
+				buffer.append(")");
 			}
 		}
 	}

--- a/src/main/java/org/snomed/snowstorm/ecl/domain/filter/SDescriptionFilterConstraint.java
+++ b/src/main/java/org/snomed/snowstorm/ecl/domain/filter/SDescriptionFilterConstraint.java
@@ -16,13 +16,6 @@ public class SDescriptionFilterConstraint extends DescriptionFilterConstraint {
 			((STermFilter) termFilter).toString(buffer);
 		}
 
-		for (DescriptionTypeFilter descriptionTypeFilter : orEmpty(getDescriptionTypeFilters())) {
-			if (f++ > 0) {
-				buffer.append(",");
-			}
-			((SDescriptionTypeFilter) descriptionTypeFilter).toString(buffer);
-		}
-
 		for (LanguageFilter languageFilter : orEmpty(getLanguageFilters())) {
 			if (f++ > 0) {
 				buffer.append(",");
@@ -30,11 +23,39 @@ public class SDescriptionFilterConstraint extends DescriptionFilterConstraint {
 			((SLanguageFilter) languageFilter).toString(buffer);
 		}
 
+		for (DescriptionTypeFilter descriptionTypeFilter : orEmpty(getDescriptionTypeFilters())) {
+			if (f++ > 0) {
+				buffer.append(",");
+			}
+			((SDescriptionTypeFilter) descriptionTypeFilter).toString(buffer);
+		}
+
 		for (DialectFilter dialectFilter : orEmpty(getDialectFilters())) {
 			if (f++ > 0) {
 				buffer.append(",");
 			}
 			((SDialectFilter) dialectFilter).toString(buffer);
+		}
+
+		for (FieldFilter moduleFilter : orEmpty(getModuleFilters())) {
+			if (f++ > 0) {
+				buffer.append(",");
+			}
+			((SFieldFilter) moduleFilter).toString(buffer);
+		}
+
+		for (EffectiveTimeFilter effectiveTimeFilter : orEmpty(getEffectiveTimeFilters())) {
+			if (f++ > 0) {
+				buffer.append(",");
+			}
+			((SEffectiveTimeFilter) effectiveTimeFilter).toString(buffer);
+		}
+
+		for (ActiveFilter activeFilter : orEmpty(getActiveFilters())) {
+			if (f++ > 0) {
+				buffer.append(",");
+			}
+			((SActiveFilter) activeFilter).toString(buffer);
 		}
 
 		buffer.append(" }}");

--- a/src/main/java/org/snomed/snowstorm/ecl/domain/filter/SEffectiveTimeFilter.java
+++ b/src/main/java/org/snomed/snowstorm/ecl/domain/filter/SEffectiveTimeFilter.java
@@ -3,15 +3,19 @@ package org.snomed.snowstorm.ecl.domain.filter;
 import org.snomed.langauges.ecl.domain.filter.EffectiveTimeFilter;
 import org.snomed.langauges.ecl.domain.filter.NumericComparisonOperator;
 
-import java.util.Set;
+import java.util.List;
 
 public class SEffectiveTimeFilter extends EffectiveTimeFilter {
-	public SEffectiveTimeFilter(NumericComparisonOperator operator, Set<Integer> effectiveTimes) {
+
+	public SEffectiveTimeFilter() {
+	}
+
+	public SEffectiveTimeFilter(NumericComparisonOperator operator, List<Integer> effectiveTimes) {
 		super(operator, effectiveTimes);
 	}
 
 	public void toString(StringBuffer buffer) {
-		buffer.append(" effectiveTime ").append(getOperator().getText()).append(" ");
+		buffer.append(" effectiveTime ").append(getOperator().getText());
 		ECLToStringUtil.toString(buffer, getEffectiveTime());
 	}
 }

--- a/src/main/java/org/snomed/snowstorm/ecl/domain/filter/SFieldFilter.java
+++ b/src/main/java/org/snomed/snowstorm/ecl/domain/filter/SFieldFilter.java
@@ -3,6 +3,10 @@ package org.snomed.snowstorm.ecl.domain.filter;
 import org.snomed.langauges.ecl.domain.filter.FieldFilter;
 
 public class SFieldFilter extends FieldFilter {
+
+	public SFieldFilter() {
+	}
+
 	public SFieldFilter(String fieldName, boolean equals) {
 		super(fieldName, equals);
 	}

--- a/src/main/java/org/snomed/snowstorm/ecl/domain/filter/SMemberFieldFilter.java
+++ b/src/main/java/org/snomed/snowstorm/ecl/domain/filter/SMemberFieldFilter.java
@@ -20,14 +20,14 @@ public class SMemberFieldFilter extends MemberFieldFilter {
 		if (getExpressionComparisonOperator() != null) {
 			buffer.append(getExpressionComparisonOperator()).append(" ").append(((SSubExpressionConstraint)getSubExpressionConstraint()).toEclString());
 		} else if (getNumericComparisonOperator() != null) {
-			buffer.append(getNumericComparisonOperator()).append(" ").append(getNumericValue());
+			buffer.append(getNumericComparisonOperator()).append(" #").append(getNumericValue());
 		} else if (getStringComparisonOperator() != null) {
-			buffer.append(getStringComparisonOperator()).append(" ");
+			buffer.append(getStringComparisonOperator());
 			ECLToStringUtil.toStringTypedSearchTerms(buffer, getSearchTerms());
 		} else if (getBooleanComparisonOperator() != null) {
 			buffer.append(getBooleanComparisonOperator()).append(" ").append(getBooleanValue());
 		} else if (getTimeComparisonOperator() != null) {
-			buffer.append(getTimeComparisonOperator()).append(" ");
+			buffer.append(getTimeComparisonOperator());
 			ECLToStringUtil.toString(buffer, getTimeValues());
 		}
 	}

--- a/src/main/java/org/snomed/snowstorm/ecl/domain/filter/STermFilter.java
+++ b/src/main/java/org/snomed/snowstorm/ecl/domain/filter/STermFilter.java
@@ -14,7 +14,7 @@ public class STermFilter extends TermFilter {
 	}
 
 	public void toString(StringBuffer buffer) {
-		buffer.append(" term ").append(getBooleanComparisonOperator()).append(" ");
+		buffer.append(" term ").append(getBooleanComparisonOperator());
 		ECLToStringUtil.toStringTypedSearchTerms(buffer, getTypedSearchTermSet());
 	}
 }

--- a/src/test/java/org/snomed/snowstorm/ecl/BranchVersionECLCacheTest.java
+++ b/src/test/java/org/snomed/snowstorm/ecl/BranchVersionECLCacheTest.java
@@ -15,4 +15,10 @@ class BranchVersionECLCacheTest {
 				">987840791000119102, >969688801000119108 |Wrong term here|"));
 	}
 
+	@Test
+	void testFilterActive() {
+		assertEquals("<< 195967001 {{ d active = 0 }}", BranchVersionECLCache.normaliseEclString("<< 195967001 |Asthma| {{ D active = 0 }}"));
+		assertEquals("<< 195967001 {{ d active = 1 }}", BranchVersionECLCache.normaliseEclString("<< 195967001 |Asthma| {{ D active = 1 }}"));
+	}
+
 }

--- a/src/test/java/org/snomed/snowstorm/ecl/ECLQueryServiceFilterTest.java
+++ b/src/test/java/org/snomed/snowstorm/ecl/ECLQueryServiceFilterTest.java
@@ -110,6 +110,13 @@ class ECLQueryServiceFilterTest {
 	}
 
 	@Test
+	// ISTO-42
+	void testNotOverEagerCaching() {
+		assertEquals(4, select("< 64572001 |Disease| {{ D active = 1 }}").size());
+		assertEquals(1, select("< 64572001 |Disease| {{ D active = 0 }}").size());
+	}
+
+	@Test
 	void testLanguageFilters() {
 		// sv language only
 		String ecl = "< 64572001 |Disease|  {{ term = \"hjärt\", language = sv }}";

--- a/src/test/java/org/snomed/snowstorm/ecl/ECLQueryServiceFilterTestConfig.java
+++ b/src/test/java/org/snomed/snowstorm/ecl/ECLQueryServiceFilterTestConfig.java
@@ -78,6 +78,9 @@ public class ECLQueryServiceFilterTestConfig extends TestConfig {
 						.addLanguageRefsetMember(GB_EN_LANG_REFSET, ACCEPTABLE))
 				.addDescription(new Description("hjärtsjukdom").setLanguageCode("sv").setType("SYNONYM")
 						.addLanguageRefsetMember("46011000052107", PREFERRED))
+				.addDescription(new Description("Heart_disease_inactive").setActive(false)
+						.addLanguageRefsetMember(US_EN_LANG_REFSET, PREFERRED)
+						.addLanguageRefsetMember(GB_EN_LANG_REFSET, ACCEPTABLE))
 				.addRelationship(ISA, DISORDER));
 		createConceptsAndVersionCodeSystem(allConcepts, 20210131);
 		allConcepts.add(new Concept("100003").setModuleId(MODULE_A).setDefinitionStatusId(DEFINED).addDescription(new Description( "Cardiac arrest (disorder)"))

--- a/src/test/java/org/snomed/snowstorm/ecl/deserializer/ECLModelDeserializerServiceTest.java
+++ b/src/test/java/org/snomed/snowstorm/ecl/deserializer/ECLModelDeserializerServiceTest.java
@@ -197,17 +197,50 @@ class ECLModelDeserializerServiceTest {
 
 		// Concept filters
 		assertConversionTest("< 404684003 |Clinical finding| {{ C active = true }}");
+		assertConversionTest("< 56265001 |Heart disease| {{ C definitionStatusId = 900000000000074008 |Primitive| }}");
+		assertConversionTest("< 64572001 |Disease| {{ C definitionStatus = primitive }} {{ D term = \"heart\" }}",
+				"< 64572001 |Disease| {{ C definitionStatusId = 900000000000074008 |Primitive| }} {{ D term = \"heart\" }}");
+		assertConversionTest("< 195967001 |Asthma| {{ C definitionStatus = primitive, moduleId = 900000000000207008 |SNOMED CT core module| }}",
+				"< 195967001 |Asthma| {{ C definitionStatusId = 900000000000074008 |Primitive| moduleId = 900000000000207008 |SNOMED CT core module| }}");
+		assertConversionTest("< 125605004 |Fracture of bone| {{ C effectiveTime >= \"20190731\" }}");
+		assertConversionTest("< 125605004 |Fracture of bone| {{ C effectiveTime != (\"20190131\" \"20190731\" \"20200131\" \"20200731\") }}");
+		assertConversionTest("^ 816080008 |International Patient Summary| {{ C active = 1 }}",
+				"^ 816080008 |International Patient Summary| {{ C active = true }}");
+		assertConversionTest("^ 816080008 |International Patient Summary| {{ C active = false }}");
 
 		// Description filters
 		assertConversionTest("< 64572001 |Disease| {{ D term = \"box\", type = syn, dialect = en-us (prefer) }}");
 		assertConversionTest("< 404684003 |Clinical finding| {{ D term = \"heart\" }}");
 		assertConversionTest("< 64572001 |Disease| {{ D term = \"hjärt\", language = sv }} {{ D term = \"heart\", language = en }}");
 		assertConversionTest("< 125605004 |Fracture of bone| minus < 125605004 |Fracture of bone| {{ D term != \"fracture\" }}");
+		assertConversionTest("< 64572001 |Disease| {{ term = \"heart\", term = \"att\" }}",
+				"< 64572001 |Disease| {{ D term = \"heart\", term = \"att\" }}");
+		assertConversionTest("< 64572001 |Disease| {{ D term = match:\"heart att\" }}",
+				"< 64572001 |Disease| {{ D term = \"heart att\" }}");
+		assertConversionTest("< 64572001 |Disease| {{ D term = (\"heart\" \"card\") }}");
+		assertConversionTest("< 64572001 |Disease| {{ D term = wild:\"cardi*opathy\" }}");
+		assertConversionTest("< 64572001 |Disease| {{ D term = (match:\"gas\" wild:\"*itis\") }}");
+		assertConversionTest("< 64572001 |Disease| {{ D term = \"eye\" }} {{ D term = wild:\"*itis\" }}");
+		assertConversionTest("< 56265001 |Heart disease| {{ D term = \"hjärt\", language = SV, type = syn }}");
+		assertConversionTest("< 56265001 |Heart disease| {{ D term = \"heart\", typeId = ( 900000000000013009 |Synonym| 900000000000003001 |Fully specified name| ) }}",
+				"< 56265001 |Heart disease| {{ D term = \"heart\", type = (syn fsn) }}");
+		assertConversionTest("< 64572001 |Disease| {{ D dialect = en-au }}");
+		assertConversionTest("< 64572001 |Disease| {{ D term = \"card\", dialect = (en-nhs-clinical en-nhs-pharmacy) }}");
+		assertConversionTest("< 64572001 |Disease| {{ D term = \"box\", type = syn, dialect = en-nhs-clinical (prefer), dialect = en-gb (accept) }}");
+		assertConversionTest("< 404684003 |Clinical finding| {{ D type = def, moduleId = 900000000000207008 |SNOMED CT core module| }}");
+		assertConversionTest("< 125605004 |Fracture of bone| {{ D effectiveTime <= \"20190731\" }}");
+		assertConversionTest("< 125605004 |Fracture of bone| {{ D effectiveTime != (\"20190131\" \"20190731\" \"20200131\" \"20200731\") }}");
+		assertConversionTest("^ 816080008 |International Patient Summary| {{ D active = 1 }}",
+				"^ 816080008 |International Patient Summary| {{ D active = true }}");
+		assertConversionTest("^ 816080008 |International Patient Summary| {{ D active = false }}");
 
 		// Member filters
 		assertConversionTest("^ 447562003 |ICD-10 complex map reference set| {{ M mapTarget = \"J45.9\" }}");
 		assertConversionTest("^ 447562003 |ICD-10 complex map reference set| {{ M active = true }}");
 		assertConversionTest("^ 447562003 |ICD-10 complex map reference set| {{ M active = false }}");
+		assertConversionTest("^ 447562003 |ICD-10 complex map reference set| {{ M mapTarget = wild:\"J45.9\" }}");
+		assertConversionTest("^ 447562003 |ICD-10 complex map reference set| {{ M mapGroup = #2, mapPriority = #1, mapTarget = \"J45.9\" }}");
+		assertConversionTest("^ [targetComponentId] 900000000000527005 |SAME AS association reference set| {{ M referencedComponentId = 67415000 |Hay asthma| }}");
 
 		final SSubExpressionConstraint eclModel = (SSubExpressionConstraint) eclQueryBuilder.createQuery("^ 447562003 |ICD-10 complex map reference set| {{ M active = false }}");
 		MemberFilterConstraint memberFilterConstraint = eclModel.getMemberFilterConstraints().get(0);

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -6,4 +6,6 @@ spring.cloud.config.enabled=false
 daily-build.import.resources.readonly=false
 daily-build.delta-import.enabled=true
 cis.registration.enabled=false
-cache.ecl.enabled=false
+
+# ECL cache should be enabled so that it's included in testing.
+cache.ecl.enabled=true


### PR DESCRIPTION
In the UAT environment these ECL queries are giving the same results.
<< 195967001 |Asthma| {{ D active = 0 }}
<< 195967001 |Asthma| {{ D active = 1 }}

> After investigation I found that this is caused by an ECL cache bug.
ECL is converted from Java objects back into text for the ECL cache lookup. This issue was that some of the description filters were not being included in the text when converted.

> I have now added [unit tests covering the conversion of all filter types](https://github.com/IHTSDO/snowstorm/blob/6d9bd593352277d80f5e3e1f373ecf601835e4c0/src/test/java/org/snomed/snowstorm/ecl/deserializer/ECLModelDeserializerServiceTest.java#L198) for all component types and fixed all remaining issues in this area. I found that the description module, effectiveTime and active filters were affected, meaning that changing any of these would have no effect on the ECL results.

All issues have been resolved and unit tested.