### PR TITLE
MAINT-1921 Make test library versions consistent.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,31 +227,29 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.6.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.6.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>testcontainers</artifactId>
-			<version>1.16.2</version>
+			<version>1.17.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>elasticsearch</artifactId>
-			<version>1.16.2</version>
+			<version>1.17.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>1.16.2</version>
+			<version>1.17.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
Hi @CoderMChu,
I was not able to run unit tests on the develop branch in IDEA. I think this was due to some inconsistencies in the unit test libraries we were using. I've upgraded the test containers to latest and remove the forced old version of jupiter. This seems to have resolved the issue. If this looks good to you please merge to dev.
Kai