### PR TITLE
spring.config.additional-location

### DIFF
--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -24,7 +24,7 @@ snowstorm.rest-api.readonly=true
 ```
 Then start Snowstorm with an extra JVM parameter:
 ```bash
---spring.config.location=application-local.properties
+--spring.config.additional-location=application-local.properties
 ```
 
 ### Using command line arguments


### PR DESCRIPTION
Replace --spring.config.location with non-replacing --spring.config.additional-location.
https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#application-properties.core.spring.config.additional-location
Addresses #366
