### PR TITLE
FRI-443 Batch processing N concept changes per JMS message

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/services/traceability/Activity.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/traceability/Activity.java
@@ -57,10 +57,13 @@ public class Activity {
 		this.sourceBranch = sourceBranch;
 	}
 
-	public Collection<ConceptActivity> getChanges() {
+	public List<ConceptActivity> getChanges() {
 		return changes;
 	}
 
+	public void setChanges(List<ConceptActivity> changes) {
+		this.changes = changes;
+	}
 	@JsonIgnore
 	public Map<String, ConceptActivity> getChangesMap() {
 		return changes.stream().collect(Collectors.toMap(ConceptActivity::getConceptId, Function.identity()));

--- a/src/main/java/org/snomed/snowstorm/core/data/services/traceability/TraceabilityConsumer.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/traceability/TraceabilityConsumer.java
@@ -1,10 +1,16 @@
 package org.snomed.snowstorm.core.data.services.traceability;
 
+import com.google.common.collect.Iterables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.stereotype.Component;
+
+import java.util.Iterator;
+import java.util.List;
 
 @Component
 @Lazy
@@ -13,11 +19,37 @@ public class TraceabilityConsumer {
 	@Value("${jms.queue.prefix}")
 	private String jmsQueuePrefix;
 
+	@Value("${activemq.max.message.concept-activities}")
+	private int maxConceptActiviesPerMessage;
+
 	@Autowired
 	private JmsTemplate jmsTemplate;
 
+	private final Logger logger = LoggerFactory.getLogger(getClass());
+
 	public void accept(Activity activity) {
-		jmsTemplate.convertAndSend(jmsQueuePrefix + ".traceability", activity);
+		if (activity.getChanges().size() <= maxConceptActiviesPerMessage) {
+			jmsTemplate.convertAndSend(jmsQueuePrefix + ".traceability", activity);
+		}
+		else {
+			sendInBatches(activity);
+		}
 	}
 
+	/**
+	 * A large activity object (with too many changes) should be messaged in batches.
+	 * @param activity
+	 */
+	void sendInBatches(Activity activity) {
+		int changeListSize = activity.getChanges().size();
+		logger.info("Number of changes (concept activities) is {} and is larger than max ({}).", changeListSize, maxConceptActiviesPerMessage );
+
+		Iterator<List<Activity.ConceptActivity>> activityListItr = Iterables.partition(activity.getChanges(), maxConceptActiviesPerMessage).iterator();
+		while (activityListItr.hasNext()) {
+			Activity activityChunk = new Activity(activity.getUserId(), activity.getBranchPath(),
+			activity.getCommitTimestamp(), activity.getSourceBranch(), activity.getActivityType());
+			activityChunk.setChanges(activityListItr.next());
+			jmsTemplate.convertAndSend(jmsQueuePrefix + ".traceability", activityChunk);
+		}
+	}
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -454,6 +454,9 @@ spring.activemq.user=
 # Login password of the broker.
 spring.activemq.password=
 
+# Cap the amount of activities sent per message to prevent memory issues
+activemq.max.message.concept-activities=250
+
 # Prefix to use for queue names.
 # Useful to separate environments.
 jms.queue.prefix=default

--- a/src/test/java/org/snomed/snowstorm/core/data/services/traceability/TraceabilityConsumerTest.java
+++ b/src/test/java/org/snomed/snowstorm/core/data/services/traceability/TraceabilityConsumerTest.java
@@ -1,0 +1,59 @@
+package org.snomed.snowstorm.core.data.services.traceability;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = TraceabilityConsumer.class)
+@TestPropertySource(properties = {"jms.queue.prefix=TEST123", "activemq.max.message.concept-activities=100"})
+public class TraceabilityConsumerTest {
+
+	private final String QUEUE = "DefaultQueue";
+	private final int MAX_CHANGES = 5;
+
+
+	@Mock
+	private JmsTemplate jmsTemplate;
+
+	@InjectMocks
+	private TraceabilityConsumer t;
+
+	@Before
+	public void beforeTests() {
+		ReflectionTestUtils.setField(t, "jmsQueuePrefix", QUEUE);
+		ReflectionTestUtils.setField(t, "maxConceptActiviesPerMessage", MAX_CHANGES);
+	}
+
+	@Test
+	public void testSingleSend() {
+		t.accept(createActivity());
+		verify(jmsTemplate, times(1)).convertAndSend(anyString(), any(Activity.class));
+	}
+
+	@Test
+	public void testSend_times3() {
+		Activity a = createActivity();
+		for (int i = 0; i < 12; i++) {
+			a.addConceptActivity(String.valueOf(i));
+		}
+		t.accept(a);
+		verify(jmsTemplate, times(3)).convertAndSend(anyString(), any(Activity.class));
+	}
+
+	private Activity createActivity() {
+		return new Activity("user", "MAIN/BLA", 999999999999l, null, Activity.ActivityType.CONTENT_CHANGE);
+	}
+
+}


### PR DESCRIPTION
I opened a new PR because the other branch had some persistent git conflicts.

The idea is to send the activities in small batches (size set through a property) and store them as such in the traceability backend (no change required there, no re-assembling)