### PR TITLE
RT2-1505 - attempt to get multisearch ECL working again.

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/services/MultiSearchService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/MultiSearchService.java
@@ -72,8 +72,9 @@ public class MultiSearchService implements CommitListener {
 
 		if (ecl != null) {
 			// ECL -> conceptIds
-			MultiBranchCriteria branchesQuery = getBranchesQuery();
-			Page<Long> page = eclQueryService.selectConceptIds(ecl, branchesQuery, false, LARGE_PAGE);
+			BranchCriteria branchCriteria = versionControlHelper.getBranchCriteria("MAIN");
+			//MultiBranchCriteria branchesQuery = getBranchesQuery();
+			Page<Long> page = eclQueryService.selectConceptIds(ecl, branchCriteria, true, null, null);
 			criteria.conceptIds(page.getContent());
 		}
 


### PR DESCRIPTION
We discovered today that the ECL parameter we had added to MultiSearchService.findDescriptions() was no longer functioning after rebasing from develop, due to the multiple changes in the MultiSearchService and in the ECLQueryService. 