### PR TITLE
ISTO-54 Fixes #426 return target active flag.

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/services/ConceptService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/ConceptService.java
@@ -435,6 +435,7 @@ public class ConceptService extends ComponentService {
 					ConceptMini conceptMini = conceptMiniMap.get(concept.getConceptId());
 					conceptMini.setDefinitionStatusId(concept.getDefinitionStatusId());
 					conceptMini.setModuleId(concept.getModuleId());
+					conceptMini.setActive(concept.isActive());
 				});
 			}
 		}


### PR DESCRIPTION
Add active flag to the axiom and inferred relationship targets in the browser concept JSON response. This makes it easier to spot when a relationship points to an inactive concept.