### PR TITLE
RT2-1567 - refset multibranch searching

### DIFF
--- a/src/main/java/org/snomed/snowstorm/rest/MultiSearchController.java
+++ b/src/main/java/org/snomed/snowstorm/rest/MultiSearchController.java
@@ -50,7 +50,7 @@ public class MultiSearchController {
 			@RequestParam String term,// Required!
 			@RequestParam(required = false) Boolean active,
 			@RequestParam(required = false) Collection<String> module,
-			@RequestParam(required = false) String ecl,
+			@RequestParam(required = false) Boolean refsetsOnly,
 
 			@Parameter(description = "Set of two character language codes to match. " +
 					"The English language code 'en' will not be added automatically, in contrast to the Accept-Language header which always includes it. " +
@@ -77,7 +77,7 @@ public class MultiSearchController {
 				.conceptActive(conceptActive);
 
 		PageRequest pageRequest = ControllerHelper.getPageRequest(offset, limit);
-		Page<Description> descriptions = multiSearchService.findDescriptions(descriptionCriteria, ecl, pageRequest);
+		Page<Description> descriptions = multiSearchService.findDescriptions(descriptionCriteria, refsetsOnly, pageRequest);
 		timer.checkpoint("description search");
 
 		Map<String, List<Description>> branchDescriptions = new HashMap<>();


### PR DESCRIPTION
Switching multibranch description search to search REFSET branches also, instead of just published branches.  Also switching from passing in ECL to specifying "RefsetsOnly", and hard-coding "<446609009" as the ECL.