### PR TITLE
Use elasticksearch:7.17.9 in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.1'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.7.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.9
     container_name: elasticsearch
     environment:
       - node.name=snowstorm


### PR DESCRIPTION
snowstorm:latest is now version 8, no longer compatible with elasticsearch:7.7.0