### PR TITLE
MAINT-2064 Upgrade HAPI FHIR to SI release version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 		<spring-cloud.version>2021.0.3</spring-cloud.version>
 
 		<!-- FHIR HAPI library -->
-		<hapi.version>5.6.3-si-SNAPSHOT</hapi.version>
+		<hapi.version>5.6.3-si</hapi.version>
 
 		<docker.image.prefix>snomedinternational</docker.image.prefix>
 		<slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
This PR upgrades Snowstorm to the release version of the HAPI FHIR library in preparation for UAT.
This release jar was built by our Jenkins server and is in our nexus repo.

https://nexus3.ihtsdotools.org/service/rest/repository/browse/maven-releases/ca/uhn/hapi/fhir/hapi-fhir-server/5.6.3-si/