### PR TITLE
RT2-1567: Creating POST version of multisearch findDescriptions 

### DIFF
--- a/src/main/java/org/snomed/snowstorm/rest/MultiSearchController.java
+++ b/src/main/java/org/snomed/snowstorm/rest/MultiSearchController.java
@@ -10,7 +10,6 @@ import org.snomed.snowstorm.core.data.domain.ConceptMini;
 import org.snomed.snowstorm.core.data.domain.Description;
 import org.snomed.snowstorm.core.data.services.ConceptService;
 import org.snomed.snowstorm.core.data.services.MultiSearchService;
-import org.snomed.snowstorm.core.data.services.QueryService;
 import org.snomed.snowstorm.core.data.services.TooCostlyException;
 import org.snomed.snowstorm.core.data.services.pojo.ConceptCriteria;
 import org.snomed.snowstorm.core.data.services.pojo.DescriptionCriteria;
@@ -19,6 +18,7 @@ import org.snomed.snowstorm.core.pojo.LanguageDialect;
 import org.snomed.snowstorm.core.util.TimerUtil;
 import org.snomed.snowstorm.rest.pojo.BrowserDescriptionSearchResult;
 import org.snomed.snowstorm.rest.pojo.ItemsPage;
+import org.snomed.snowstorm.rest.pojo.MultibranchDescriptionSearchRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -77,7 +77,7 @@ public class MultiSearchController {
 				.conceptActive(conceptActive);
 
 		PageRequest pageRequest = ControllerHelper.getPageRequest(offset, limit);
-		Page<Description> descriptions = multiSearchService.findDescriptions(descriptionCriteria, ecl, pageRequest);
+		Page<Description> descriptions = multiSearchService.findDescriptions(descriptionCriteria, ecl, pageRequest, null);
 		timer.checkpoint("description search");
 
 		Map<String, List<Description>> branchDescriptions = new HashMap<>();
@@ -105,6 +105,71 @@ public class MultiSearchController {
 
 		return new ItemsPage<>(new PageImpl<>(results, pageRequest, descriptions.getTotalElements()));
 	}
+
+	@Operation(description = "Search descriptions across multiple Code Systems. Can search specified branches in addition to all published branches.")
+	@PostMapping(value = "multisearch/descriptions", produces = {"application/json", "text/csv"})
+	@JsonView(value = View.Component.class)
+	public ItemsPage<BrowserDescriptionSearchResult> findDescriptionsIncludingRequestedBranches(
+			@RequestParam String term,// Required!
+			@RequestParam(required = false) Boolean active,
+			@RequestParam(required = false) Collection<String> module,
+			@RequestParam(required = false) String ecl,
+
+			@Parameter(description = "Set of two character language codes to match. " +
+					"The English language code 'en' will not be added automatically, in contrast to the Accept-Language header which always includes it. " +
+					"Accept-Language header still controls result FSN and PT language selection.")
+			@RequestParam(required = false) Set<String> language,
+
+			@Parameter(name = "Set of description types to include. Pick descendants of '900000000000446008 | Description type (core metadata concept) |'.")
+			@RequestParam(required = false) Set<Long> type,
+
+			@RequestParam(required = false) Boolean conceptActive,
+			@RequestParam(defaultValue = "ALL_PUBLISHED_CONTENT") ContentScope contentScope,
+			@RequestParam(defaultValue = "0") int offset,
+			@RequestParam(defaultValue = "50") int limit,
+			@RequestBody MultibranchDescriptionSearchRequest includeBranches,
+			@RequestHeader(value = "Accept-Language", defaultValue = Config.DEFAULT_ACCEPT_LANG_HEADER) String acceptLanguageHeader) throws TooCostlyException {
+
+		TimerUtil timer = new TimerUtil("MultiSearch - Descriptions");
+
+		DescriptionCriteria descriptionCriteria = new DescriptionCriteria()
+				.term(term)
+				.active(active)
+				.modules(module)
+				.searchLanguageCodes(language)
+				.type(type)
+				.conceptActive(conceptActive);
+
+		PageRequest pageRequest = ControllerHelper.getPageRequest(offset, limit);
+		Page<Description> descriptions = multiSearchService.findDescriptions(descriptionCriteria, ecl, pageRequest, includeBranches.getBranches());
+		timer.checkpoint("description search");
+
+		Map<String, List<Description>> branchDescriptions = new HashMap<>();
+		Map<String, List<String>> branchConceptIds = new HashMap<>();
+		for (Description description : descriptions) {
+			branchDescriptions.computeIfAbsent(description.getPath(), s -> new ArrayList<>()).add(description);
+			branchConceptIds.computeIfAbsent(description.getPath(), s -> new ArrayList<>()).add(description.getConceptId());
+		}
+
+		List<LanguageDialect> languageDialects = ControllerHelper.parseAcceptLanguageHeaderWithDefaultFallback(acceptLanguageHeader);
+		Map<String, ConceptMini> conceptMiniMap = new HashMap<>();
+		for (String branchPath : branchConceptIds.keySet()) {
+			conceptMiniMap.putAll(conceptService.findConceptMinis(branchPath, branchConceptIds.get(branchPath), languageDialects).getResultsMap());
+			timer.checkpoint("Join concepts from " + branchPath);
+		}
+
+		List<BrowserDescriptionSearchResult> results = new ArrayList<>();
+		for (Description description : descriptions) {
+			BrowserDescriptionSearchResult result = new BrowserDescriptionSearchResult(description.getTerm(), description.isActive(), description.getLanguageCode(),
+					description.getModuleId(), conceptMiniMap.get(description.getConceptId()));
+			result.addExtraField("branchPath", description.getPath());
+			results.add(result);
+		}
+		timer.finish();
+
+		return new ItemsPage<>(new PageImpl<>(results, pageRequest, descriptions.getTotalElements()));
+	}
+	
 	
 	@Operation(summary = "Search descriptions across multiple Code Systems returning reference set membership bucket.")
 	@GetMapping(value = "multisearch/descriptions/referencesets")

--- a/src/main/java/org/snomed/snowstorm/rest/pojo/MultibranchDescriptionSearchRequest.java
+++ b/src/main/java/org/snomed/snowstorm/rest/pojo/MultibranchDescriptionSearchRequest.java
@@ -1,0 +1,20 @@
+package org.snomed.snowstorm.rest.pojo;
+
+import java.util.Set;
+
+public class MultibranchDescriptionSearchRequest {
+
+	private Set<String> branches;
+
+	public MultibranchDescriptionSearchRequest() {
+	}
+
+	public void setBranches(Set<String> branches) {
+		this.branches = branches;
+	}
+	
+	public Set<String> getBranches() {
+		return branches;
+	}
+
+}

--- a/src/test/java/org/snomed/snowstorm/core/data/services/MultiSearchServiceTest.java
+++ b/src/test/java/org/snomed/snowstorm/core/data/services/MultiSearchServiceTest.java
@@ -95,7 +95,7 @@ class MultiSearchServiceTest extends AbstractTest {
 
 	private Page<Description> runSearch(String term) {
 		DescriptionCriteria criteria = new DescriptionCriteria().term(term);
-		return multiSearchService.findDescriptions(criteria, null, PageRequest.of(0, 10));
+		return multiSearchService.findDescriptions(criteria, null, PageRequest.of(0, 10),null);
 	}
 
 	private Page<Description> runSearch(String term, Boolean conceptActive) {
@@ -103,7 +103,7 @@ class MultiSearchServiceTest extends AbstractTest {
 			return runSearch(term);
 		} else {
 			DescriptionCriteria criteria = new DescriptionCriteria().term(term).conceptActive(conceptActive);
-			return multiSearchService.findDescriptions(criteria, null, PageRequest.of(0, 10));
+			return multiSearchService.findDescriptions(criteria, null, PageRequest.of(0, 10),null);
 		}
 	}
 }


### PR DESCRIPTION
The intention is to allow users to specify additional, non-published branches to include in the search.  This will be used by RT2 to search refset names across all branches, and can potentially be useful to other others as well.