### PR TITLE
ISTO-94 Snowstorm FHIR Inctive Flag

### DIFF
--- a/src/main/java/org/snomed/snowstorm/fhir/services/FHIRValueSetService.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/FHIRValueSetService.java
@@ -584,6 +584,9 @@ public class FHIRValueSetService {
 		for (Coding codingA : codings) {
 			FHIRConcept concept = findInValueSet(codingA, resolvedCodeSystemVersionsMatchingCodings, codeSelectionCriteria, languageDialects);
 			if (concept != null) {
+				if (codings.size() == 1 && FHIRHelper.isSnomedUri(codingA.getSystem())) {
+					response.addParameter("inactive", !concept.isActive());
+				}
 				String codingADisplay = codingA.getDisplay();
 				if (codingADisplay == null) {
 					response.addParameter("result", true);

--- a/src/main/java/org/snomed/snowstorm/fhir/services/FHIRValueSetService.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/FHIRValueSetService.java
@@ -341,7 +341,7 @@ public class FHIRValueSetService {
 					ValueSet.ValueSetExpansionContainsComponent component = new ValueSet.ValueSetExpansionContainsComponent()
 							.setSystem(idAndVersionToUrl.get(concept.getCodeSystemVersion()))
 							.setCode(concept.getCode())
-							.setInactiveElement(concept.isActive() ? null : new BooleanType(false))
+							.setInactiveElement(concept.isActive() ? null : new BooleanType(true))
 							.setDisplay(concept.getDisplay());
 					if (includeDesignations) {
 						for (FHIRDesignation designation : concept.getDesignations()) {

--- a/src/main/java/org/snomed/snowstorm/fhir/services/HapiParametersMapper.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/HapiParametersMapper.java
@@ -36,6 +36,7 @@ public class HapiParametersMapper implements FHIRConstants {
 			parameters.addParameter("result", valid);
 		}
 		parameters.addParameter("display", concept.getPt().getTerm());
+		parameters.addParameter("inactive", !concept.isActive());
 		addSystemAndVersion(parameters, codeSystemVersion);
 		return parameters;
 	}

--- a/src/main/java/org/snomed/snowstorm/fhir/services/HapiParametersMapper.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/HapiParametersMapper.java
@@ -87,7 +87,7 @@ public class HapiParametersMapper implements FHIRConstants {
 		parameters.addParameter("display", fhirHelper.getPreferredTerm(concept, designations));
 		parameters.addParameter("name", codeSystem.getTitle());
 		addSystemAndVersion(parameters, codeSystem);
-		parameters.addParameter("active", concept.isActive());
+		parameters.addParameter("inactive", !concept.isActive());
 		addProperties(parameters, concept, properties);
 		addDesignations(parameters, concept);
 		addParents(parameters, concept);

--- a/src/test/java/org/snomed/snowstorm/fhir/services/FHIRCodeSystemProviderLookupTest.java
+++ b/src/test/java/org/snomed/snowstorm/fhir/services/FHIRCodeSystemProviderLookupTest.java
@@ -41,16 +41,16 @@ class FHIRCodeSystemProviderLookupTest extends AbstractFHIRTest {
 	void testParameterActiveWhenActive() {
 		String url = "http://localhost:" + port + "/fhir/CodeSystem/$lookup?system=http://snomed.info/sct&code=" + sampleSCTID + "&property=normalForm&property=sufficientlyDefined&_format=json";
 		Parameters p = getParameters(url);
-		Boolean active = toBoolean(getProperty(p, "active"));
-		assertTrue(active);
+		Boolean inactive = toBoolean(getProperty(p, "inactive"));
+		assertFalse(inactive);
 	}
 
 	@Test
 	void testParameterActiveWhenInactive() {
 		String url = "http://localhost:" + port + "/fhir/CodeSystem/$lookup?system=http://snomed.info/sct&code=" + sampleInactiveSCTID + "&property=normalForm&property=sufficientlyDefined&_format=json";
 		Parameters p = getParameters(url);
-		Boolean active = toBoolean(getProperty(p, "active"));
-		assertFalse(active);
+		Boolean inactive = toBoolean(getProperty(p, "inactive"));
+		assertTrue(inactive);
 	}
 	
 	@Test

--- a/src/test/java/org/snomed/snowstorm/fhir/services/FHIRCodeSystemProviderValidateTest.java
+++ b/src/test/java/org/snomed/snowstorm/fhir/services/FHIRCodeSystemProviderValidateTest.java
@@ -4,8 +4,7 @@ import org.hl7.fhir.r4.model.Parameters;
 import org.junit.jupiter.api.Test;
 
 import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.snomed.snowstorm.fhir.config.FHIRConstants.SNOMED_URI;
 
 class FHIRCodeSystemProviderValidateTest extends AbstractFHIRTest {
@@ -18,7 +17,9 @@ class FHIRCodeSystemProviderValidateTest extends AbstractFHIRTest {
 		Parameters p = getParameters(url);
 		String result = toString(getProperty(p, "result"));
 		assertEquals("true", result);
-		
+		Boolean inactive = toBoolean(getProperty(p, "inactive"));
+		assertFalse(inactive);
+
 		//Alternative URLs using coding saying the same thing
 		url = "http://localhost:" + port + "/fhir/CodeSystem/$validate-code?" + version + "&coding=http://snomed.info/sct|" + sampleSCTID;
 		p = getParameters(url);
@@ -56,7 +57,19 @@ class FHIRCodeSystemProviderValidateTest extends AbstractFHIRTest {
 		assertEquals("false", result);
 		//TODO However we do get the actual PT here, so check that
 	}
-	
+
+	@Test
+	void testValidateCodeInactive() {
+		String version = "version=http://snomed.info/sct/1234000008";
+		//Test recovery using code with version
+		String url = "http://localhost:" + port + "/fhir/CodeSystem/$validate-code?url=" + SNOMED_URI + "&" + version + "&code=" + sampleInactiveSCTID;
+		Parameters p = getParameters(url);
+		String result = toString(getProperty(p, "result"));
+		assertEquals("true", result);
+		Boolean inactive = toBoolean(getProperty(p, "inactive"));
+		assertTrue(inactive);
+	}
+
 	@Test
 	void testValidateUnpublishedCode() {
 		String version = "version=http://snomed.info/xsct/" + sampleModuleId;

--- a/src/test/java/org/snomed/snowstorm/fhir/services/FHIRValueSetProviderExpandTest.java
+++ b/src/test/java/org/snomed/snowstorm/fhir/services/FHIRValueSetProviderExpandTest.java
@@ -1,6 +1,7 @@
 package org.snomed.snowstorm.fhir.services;
 
 import ca.uhn.fhir.rest.api.MethodOutcome;
+import org.hl7.fhir.r4.model.ValueSet;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
@@ -8,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FHIRValueSetProviderExpandTest extends AbstractFHIRTest {
 
@@ -38,11 +40,44 @@ public class FHIRValueSetProviderExpandTest extends AbstractFHIRTest {
 			"    ]\n" +
 			"}";
 
+	private static final String VALUE_SET_WITH_INACTIVE_CODE = "{\n" +
+			"    \"resourceType\": \"Parameters\",\n" +
+			"    \"parameter\": [\n" +
+			"        {\n" +
+			"            \"name\": \"valueSet\",\n" +
+			"            \"resource\": {\n" +
+			"                \"resourceType\": \"ValueSet\",\n" +
+			"                \"compose\": {\n" +
+			"                    \"include\": [\n" +
+			"                        {\n" +
+			"                            \"system\": \"http://snomed.info/sct\",\n" +
+			"                            \"concept\": [ { \"code\": \"" + sampleInactiveSCTID + "\" } ]" +
+			"                        }\n" +
+			"                    ]\n" +
+			"                }\n" +
+			"            }\n" +
+			"        }\n" +
+			"    ]\n" +
+			"}";
+
 	@Test
 	public void testExpandThrowsFHIROperationExceptionIfVersionUsedWhilePerformingPOSTOperation() {
 		HttpEntity<String> request = new HttpEntity<>(VALUE_SET_EXPANSION_POST_BODY_WITH_VERSION, headers);
 		ResponseEntity<MethodOutcome> response = restTemplate.exchange(baseUrl + "/ValueSet/$expand", HttpMethod.POST, request, MethodOutcome.class);
 		assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+	}
+
+	@Test
+	public void testExpandInactiveCodeViaPOST() {
+		HttpEntity<String> request = new HttpEntity<>(VALUE_SET_WITH_INACTIVE_CODE, headers);
+		ResponseEntity<String> response = restTemplate.exchange(baseUrl + "/ValueSet/$expand", HttpMethod.POST, request, String.class);
+		ValueSet valueSet = fhirJsonParser.parseResource(ValueSet.class, response.getBody());
+
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		ValueSet.ValueSetExpansionContainsComponent concept = valueSet.getExpansion().getContains().get(0);
+		assertEquals("http://snomed.info/sct", concept.getSystem());
+		assertEquals("60363000", concept.getCode());
+		assertTrue(concept.getInactive());
 	}
 
 }


### PR DESCRIPTION
This PR contains various fixes for the Snowstorm FHIR interface relating to the inactive flag.
- Fixed ValueSet $expand
  - inactive flag was inverted)
- Fixed CodeSystem $lookup
  - Added "inactive" property to conform with standard
  - Removed "active" property because redundant
- Added "inactive" property to CodeSystem $validate-code
- Added "inactive" property to ValueSet $validate-code