### PR TITLE
ISTO-95 Block FULL import unless on empty MAIN.

### DIFF
--- a/src/main/java/org/snomed/snowstorm/config/Config.java
+++ b/src/main/java/org/snomed/snowstorm/config/Config.java
@@ -45,7 +45,6 @@ import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestCli
 import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
-import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration;

--- a/src/main/java/org/snomed/snowstorm/core/rf2/rf2import/ImportService.java
+++ b/src/main/java/org/snomed/snowstorm/core/rf2/rf2import/ImportService.java
@@ -82,6 +82,13 @@ public class ImportService {
 			throw new IllegalArgumentException(String.format("Branch %s does not exist.", branchPath));
 		}
 
+		if (importConfiguration.getType() == FULL) {
+			Branch latest = branchService.findLatest(branchPath);
+			if (!branchPath.equals("MAIN") || latest.isContainsContent()) {
+				throw new IllegalArgumentException("FULL import is only implemented for the MAIN branch and when there is no existing content.");
+			}
+		}
+
 		if (importConfiguration.isCreateCodeSystemVersion()) {
 			// Check there is a code system on this branch
 			Optional<CodeSystem> optionalCodeSystem = codeSystemService.findAll().stream().filter(codeSystem -> codeSystem.getBranchPath().equals(branchPath)).findAny();

--- a/src/test/java/org/snomed/snowstorm/core/rf2/rf2import/ImportServiceTest.java
+++ b/src/test/java/org/snomed/snowstorm/core/rf2/rf2import/ImportServiceTest.java
@@ -223,6 +223,19 @@ class ImportServiceTest extends AbstractTest {
 		assertNull(report2011JanInferred.getRelationshipsWithMissingOrInactiveDestination());
 	}
 
+	@Test
+	void testImportFullOnChildCodeSystem() {
+		String branchPath = "MAIN/SNOMEDCT-TEST";
+		codeSystemService.createCodeSystem(new CodeSystem("SNOMEDCT-TEST", branchPath));
+
+		try {
+			importService.createJob(RF2Type.FULL, branchPath, true, false);
+			fail("Should have thrown error before this line");
+		} catch (IllegalArgumentException e) {
+			assertEquals("FULL import is only implemented for the MAIN branch and when there is no existing content.", e.getMessage());
+		}
+	}
+
 	private String mapToString(Map<Long, Long> map) {
 		// Sort the map before converting to string to ensure consistent output
 		return new TreeMap<>(map).toString();
@@ -694,8 +707,7 @@ class ImportServiceTest extends AbstractTest {
 	@Test
 	public void importArchive_ShouldSuccessfullyImportConcreteRelationship_WhenImportingFull() throws IOException, ReleaseImportException {
 		//given
-		final String branchPath = "MAIN/CDI-29";
-		branchService.create(branchPath);
+		final String branchPath = "MAIN";
 		final String importJobId = importService.createJob(RF2Type.FULL, branchPath, false, false);
 		final File zipFile = ZipUtil.zipDirectoryRemovingCommentsAndBlankLines("src/test/resources/dummy-snomed-content/SnomedCT_MiniRF2");
 		final FileInputStream releaseFileStream = new FileInputStream(zipFile);


### PR DESCRIPTION
This PR stops anyone using the FULL import on branches other than MAIN. The branch also needs to be empty. This block should have been there from the start because all content is imported against the current parent code system version, this is incorrect behaviour.
A complete child Edition/Extension import feature could be implemented in the future.