### PR TITLE
Fix MAINT-2227 - Issues loading LOINC package

### DIFF
--- a/src/main/java/org/snomed/snowstorm/fhir/domain/ConceptConstraint.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/domain/ConceptConstraint.java
@@ -1,6 +1,9 @@
 package org.snomed.snowstorm.fhir.domain;
 
+import org.springframework.util.CollectionUtils;
+
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Set;
 
 public class ConceptConstraint {
@@ -15,6 +18,10 @@ public class ConceptConstraint {
 
 	public ConceptConstraint(Collection<String> code) {
 		this.code = code;
+	}
+
+	public boolean isSimpleCodeSet() {
+		return CollectionUtils.isEmpty(parent) && CollectionUtils.isEmpty(ancestor) && ecl == null && !CollectionUtils.isEmpty(code);
 	}
 
 	public ConceptConstraint setParent(Set<String> parent) {
@@ -50,5 +57,18 @@ public class ConceptConstraint {
 
 	public String getEcl() {
 		return ecl;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		ConceptConstraint that = (ConceptConstraint) o;
+		return Objects.equals(code, that.code) && Objects.equals(parent, that.parent) && Objects.equals(ancestor, that.ancestor) && Objects.equals(ecl, that.ecl);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(code, parent, ancestor, ecl);
 	}
 }

--- a/src/main/java/org/snomed/snowstorm/fhir/services/CodeSelectionCriteria.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/CodeSelectionCriteria.java
@@ -2,6 +2,7 @@ package org.snomed.snowstorm.fhir.services;
 
 import org.snomed.snowstorm.fhir.domain.ConceptConstraint;
 import org.snomed.snowstorm.fhir.domain.FHIRCodeSystemVersion;
+import org.springframework.util.CollectionUtils;
 
 import java.util.*;
 
@@ -17,6 +18,11 @@ public class CodeSelectionCriteria {
 		inclusionConstraints = new HashMap<>();
 		nestedSelections = new HashSet<>();
 		exclusionConstraints = new HashMap<>();
+	}
+
+	public boolean isOnlyInclusionsForOneVersionAndAllSimple() {
+		return CollectionUtils.isEmpty(nestedSelections) && CollectionUtils.isEmpty(exclusionConstraints) && !CollectionUtils.isEmpty(inclusionConstraints)
+				&& inclusionConstraints.keySet().size() == 1 && inclusionConstraints.values().stream().flatMap(Collection::stream).allMatch(ConceptConstraint::isSimpleCodeSet);
 	}
 
 	public Set<ConceptConstraint> addInclusion(FHIRCodeSystemVersion codeSystemVersion) {
@@ -63,5 +69,18 @@ public class CodeSelectionCriteria {
 			nestedSelection.doGatherAllInclusionVersions(versions);
 		}
 		return versions;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		CodeSelectionCriteria that = (CodeSelectionCriteria) o;
+		return Objects.equals(valueSetUserRef, that.valueSetUserRef) && Objects.equals(inclusionConstraints, that.inclusionConstraints) && Objects.equals(nestedSelections, that.nestedSelections) && Objects.equals(exclusionConstraints, that.exclusionConstraints);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(valueSetUserRef, inclusionConstraints, nestedSelections, exclusionConstraints);
 	}
 }

--- a/src/main/java/org/snomed/snowstorm/fhir/services/FHIRTermCodeSystemStorage.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/FHIRTermCodeSystemStorage.java
@@ -68,7 +68,7 @@ public class FHIRTermCodeSystemStorage implements ITermCodeSystemStorageSvc {
 
 		valueSets = orEmpty(valueSets);
 		logger.info("{} ValueSets found", valueSets.size());
-		fhirValueSetService.saveAllValueSetsOfCodeSystemVersion(valueSets);
+		fhirValueSetService.saveAllValueSetsOfCodeSystemVersionWithoutExpandValidation(valueSets);
 
 		conceptMaps = orEmpty(conceptMaps);
 		logger.info("{} ConceptMaps found", conceptMaps.size());

--- a/src/main/java/org/snomed/snowstorm/fhir/services/FHIRTermCodeSystemStorage.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/FHIRTermCodeSystemStorage.java
@@ -81,6 +81,7 @@ public class FHIRTermCodeSystemStorage implements ITermCodeSystemStorageSvc {
 			}
 		}
 
+		logger.info("Code System import complete for {}.", codeSystem.getUrl());
 		return new IdType("CodeSystem", codeSystemVersion.getId(), codeSystemVersion.getVersion());
 	}
 

--- a/src/main/java/org/snomed/snowstorm/fhir/services/FHIRValueSetService.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/FHIRValueSetService.java
@@ -116,11 +116,11 @@ public class FHIRValueSetService {
 		return Optional.empty();
 	}
 
-	public void saveAllValueSetsOfCodeSystemVersion(List<ValueSet> valueSets) {
+	public void saveAllValueSetsOfCodeSystemVersionWithoutExpandValidation(List<ValueSet> valueSets) {
 		for (ValueSet valueSet : orEmpty(valueSets)) {
 			try {
 				logger.info("Saving ValueSet {}", valueSet.getIdElement());
-				createOrUpdateValueset(valueSet);
+				createOrUpdateValuesetWithoutExpandValidation(valueSet);
 			} catch (SnowstormFHIRServerResponseException e) {
 				logger.error("Failed to store value set {}", valueSet.getIdElement(), e);
 			}


### PR DESCRIPTION
These commits fix the LOINC package loading issues. The changes are:
- Stop attempting to expand ValueSet resources during import. This was leading to issues when nested value sets were not yet imported.
- When a user expands a value set simplify the Elasticsearch clauses for nested value sets to prevent the clause limit being exceeded for some LOINC sets.