### PR TITLE
ISTO-99 Snowstorm refset member API, add details to support SRS manifest generation

### DIFF
--- a/src/main/java/org/snomed/snowstorm/config/SecurityAndUriConfig.java
+++ b/src/main/java/org/snomed/snowstorm/config/SecurityAndUriConfig.java
@@ -15,6 +15,7 @@ import org.ihtsdo.drools.domain.Component;
 import org.ihtsdo.drools.response.InvalidContent;
 import org.ihtsdo.sso.integration.RequestHeaderAuthenticationDecorator;
 import org.snomed.snowstorm.core.data.domain.CodeSystemVersion;
+import org.snomed.snowstorm.core.data.domain.ReferenceSetType;
 import org.snomed.snowstorm.core.data.domain.classification.Classification;
 import org.snomed.snowstorm.rest.ReadOnlyApi;
 import org.snomed.snowstorm.rest.ReadOnlyApiWhenEnabled;
@@ -86,7 +87,8 @@ public class SecurityAndUriConfig {
 				.mixIn(Classification.class, ClassificationMixIn.class)
 				.mixIn(CodeSystemVersion.class, CodeSystemVersionMixIn.class)
 				.mixIn(InvalidContent.class, InvalidContentMixIn.class)
-				.mixIn(Component.class, ComponentMixIn.class);
+				.mixIn(Component.class, ComponentMixIn.class)
+				.mixIn(ReferenceSetType.class, ReferenceSetTypeMixin.class);
 
 		if (jsonIndentOutput) {
 			builder.featuresToEnable(SerializationFeature.INDENT_OUTPUT);

--- a/src/main/java/org/snomed/snowstorm/core/data/services/ReferenceSetMemberService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/ReferenceSetMemberService.java
@@ -695,10 +695,15 @@ public class ReferenceSetMemberService extends ComponentService {
 				refsetToTypeMap.put(conceptId, conceptId);
 			} else {
 				String type = null;
-				for (Long ancestor : semanticIndexRefsetConcept.getAncestors()) {
-					if (refsetTypesFromConfig.contains(ancestor.toString())) {
-						// Refset ancestor matches one of the configured types. These are generally more specific than those in the hierarchy.
-						type = ancestor.toString();
+				if (refsetTypesFromConfig.contains(conceptId)) {
+					// Refset matches one of the configured types. These are generally more specific than those in the hierarchy.
+					type = conceptId;
+				} else {
+					for (Long ancestor : semanticIndexRefsetConcept.getAncestors()) {
+						if (refsetTypesFromConfig.contains(ancestor.toString())) {
+							// Refset ancestor matches one of the configured types. These are generally more specific than those in the hierarchy.
+							type = ancestor.toString();
+						}
 					}
 				}
 				if (type == null) {

--- a/src/main/java/org/snomed/snowstorm/rest/ReferenceSetMemberController.java
+++ b/src/main/java/org/snomed/snowstorm/rest/ReferenceSetMemberController.java
@@ -10,10 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.commons.lang3.SerializationUtils;
 import org.elasticsearch.common.util.set.Sets;
 import org.snomed.snowstorm.config.Config;
-import org.snomed.snowstorm.core.data.domain.ConceptMini;
-import org.snomed.snowstorm.core.data.domain.Description;
-import org.snomed.snowstorm.core.data.domain.ReferenceSetMember;
-import org.snomed.snowstorm.core.data.domain.ReferenceSetMemberView;
+import org.snomed.snowstorm.core.data.domain.*;
 import org.snomed.snowstorm.core.data.services.ConceptService;
 import org.snomed.snowstorm.core.data.services.DescriptionService;
 import org.snomed.snowstorm.core.data.services.ReferenceSetMemberService;
@@ -93,11 +90,12 @@ public class ReferenceSetMemberController {
 
 		// Find refset type
 		BranchCriteria branchCriteria = versionControlHelper.getBranchCriteria(branch);
-		Map<String, String> refsetTypes = memberService.findRefsetTypes(referenceSetIds, branchCriteria, branch);
+		Map<String, String> refsetTypes = memberService.findRefsetTypes(referenceSetIds, branchCriteria);
+		Map<String, ReferenceSetType> configuredTypesMap = memberService.getConfiguredTypesMap();
 		timer.checkpoint("load types (" + referenceSetIds.size() + ")");
 
 		// Load concept minis
-		Map<String, ConceptMini> conceptMinis = conceptService.findConceptMinis(branch, Sets.union(referenceSetIds, new HashSet<>(refsetTypes.values())), languageDialects).getResultsMap();
+		Map<String, ConceptMini> conceptMinis = conceptService.findConceptMinis(branchCriteria, Sets.union(referenceSetIds, new HashSet<>(refsetTypes.values())), languageDialects).getResultsMap();
 		Map<String, ConceptMini> referenceSets = new HashMap<>();
 		for (String referenceSetId : referenceSetIds) {
 			ConceptMini refsetMini = conceptMinis.get(referenceSetId);
@@ -109,6 +107,8 @@ public class ReferenceSetMemberController {
 					if (refsetMini == typeConcept) {
 						typeConcept = SerializationUtils.clone(typeConcept);
 					}
+					// If refset type exists in the Snowstorm RF2 export configuration then add file/fields info to the response
+					typeConcept.addExtraField("fileConfiguration", configuredTypesMap.get(type));
 					refsetMini.addExtraField("referenceSetType", typeConcept);
 				}
 				referenceSets.put(referenceSetId, refsetMini);

--- a/src/main/java/org/snomed/snowstorm/rest/config/ReferenceSetTypeMixin.java
+++ b/src/main/java/org/snomed/snowstorm/rest/config/ReferenceSetTypeMixin.java
@@ -1,0 +1,22 @@
+package org.snomed.snowstorm.rest.config;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public interface ReferenceSetTypeMixin {
+
+	@JsonIgnore
+	boolean isChanged();
+
+	@JsonIgnore
+	boolean isDeleted();
+
+	@JsonIgnore
+	String getFieldNames();
+
+	@JsonIgnore
+	String getConceptId();
+
+	@JsonIgnore
+	String getId();
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -178,8 +178,8 @@ refset.types.MRCMAttributeRange=723592007|Metadata|sscc|rangeConstraint,attribut
 refset.types.RefsetDescriptor=900000000000456007|Metadata|cci|attributeDescription,attributeType,attributeOrder
 refset.types.ModuleDependency=900000000000534007|Metadata|ss|sourceEffectiveTime,targetEffectiveTime
 refset.types.DescriptionType=900000000000538005|Metadata|ci|descriptionFormat,descriptionLength
-refset.types.ICD-9-CMEquivalenceComplexMap=447563008|Map|iisssc|mapGroup,mapPriority,mapRule,mapAdvice,mapTarget,correlationId
-refset.types.ICD-10ExtendedMap=447562003|Map|iissscc|mapGroup,mapPriority,mapRule,mapAdvice,mapTarget,correlationId,mapCategoryId
+refset.types.ComplexMap=447250001|Map|iisssc|mapGroup,mapPriority,mapRule,mapAdvice,mapTarget,correlationId
+refset.types.ExtendedMap=609331003|Map|iissscc|mapGroup,mapPriority,mapRule,mapAdvice,mapTarget,correlationId,mapCategoryId
 
 
 # ----------------------------------------


### PR DESCRIPTION
This PR updates the browser member API endpoint to add more details about each refset type. This is required to support generating SNOMED Release Service manifest xml files in the upcoming Simplex Tool.

I have also fixed the Snowstorm refset configuration for the ICD-10 and ICD-9-CM maps. The config now points to the generic Complex Map and Extended Map types rather than any specific refset. This is in line with the rest of the configuration and means that any other maps of these types will also pick up the correct configuration. This area of configuration is the source of the information that is now exposed in the refset API.