### PR TITLE
MAINT-2384 Fix decimal serialisation in ECL index.

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/domain/QueryConcept.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/domain/QueryConcept.java
@@ -10,6 +10,7 @@ import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 import org.springframework.data.elasticsearch.annotations.Setting;
 
+import java.text.DecimalFormat;
 import java.util.*;
 
 /**
@@ -299,10 +300,19 @@ public class QueryConcept extends DomainEntity<QueryConcept> implements FHIRGrap
 					builder.append(type);
 					builder.append("=");
 					for (Object value : attributes.get(type)) {
-						if (!(value instanceof String)) {
+						String valueString;
+						if (value instanceof String) {
+							valueString = (String) value;
+						} else {
 							builder.append("#");
+							if (value instanceof Double || value instanceof Float) {
+								// Maximum decimal places is 6 - See https://confluence.ihtsdotools.org/display/mag/Concrete+Domain+Decimal+Places+and+Rounding
+								valueString = new DecimalFormat("#0.0#####").format(value);
+							} else {
+								valueString = value.toString();
+							}
 						}
-						builder.append(value);
+						builder.append(valueString);
 						builder.append(",");
 					}
 					deleteLastCharacter(builder);

--- a/src/test/java/org/snomed/snowstorm/core/data/domain/QueryConceptTest.java
+++ b/src/test/java/org/snomed/snowstorm/core/data/domain/QueryConceptTest.java
@@ -47,12 +47,14 @@ class QueryConceptTest {
 		queryConcept.addAttribute(3, 123L, "456");
 		assertEquals("1:123=456,789:1234=123|3:123=456", queryConcept.getAttrMap());
 
-		queryConcept.addAttribute(3, 234L, 500);
-		assertEquals("1:123=456,789:1234=123|3:123=456:234=#500", queryConcept.getAttrMap());
+		queryConcept.addAttribute(3, 234L, 0.0005f);
+		assertEquals("1:123=456,789:1234=123|3:123=456:234=#0.0005", queryConcept.getAttrMap());
 
+		queryConcept.addAttribute(3, 234L, 500.0f);
+		assertEquals("1:123=456,789:1234=123|3:123=456:234=#0.0005,#500.0", queryConcept.getAttrMap());
 
 		queryConcept.addAttribute(4, 2345L, "\"test\"");
-		assertEquals("1:123=456,789:1234=123|3:123=456:234=#500|4:2345=\"test\"", queryConcept.getAttrMap());
+		assertEquals("1:123=456,789:1234=123|3:123=456:234=#0.0005,#500.0|4:2345=\"test\"", queryConcept.getAttrMap());
 
 		queryConcept.serializeGroupedAttributesMap();
 		Map<Integer, Map<String, List<Object>>> groupedAttributesMap = queryConcept.getGroupedAttributesMap();
@@ -61,16 +63,16 @@ class QueryConceptTest {
 		Map<String, Set<Object>> expectedAttrMap = new HashMap<>();
 		expectedAttrMap.put("all", Sets.newHashSet("123", "456", "789", "\"test\""));
 		expectedAttrMap.put("123", Sets.newHashSet("456", "789"));
-		expectedAttrMap.put("234", Sets.newHashSet(500));
+		expectedAttrMap.put("234", Sets.newHashSet(500.0f, 0.0005f));
 		expectedAttrMap.put("2345", Sets.newHashSet("\"test\""));
 		expectedAttrMap.put("1234", Sets.newHashSet("123"));
-		expectedAttrMap.put("all_numeric", Sets.newHashSet(500.0f));
+		expectedAttrMap.put("all_numeric", Sets.newHashSet(500.0f, 0.0005f));
 		assertEquals(expectedAttrMap, queryConcept.getAttr());
 
 		String json = objectMapper.writeValueAsString(queryConcept);
 
 		QueryConcept queryConcept2 = objectMapper.readValue(json, QueryConcept.class);
-		assertEquals("1:123=456,789:1234=123|3:123=456:234=#500|4:2345=\"test\"", queryConcept2.getAttrMap());
+		assertEquals("1:123=456,789:1234=123|3:123=456:234=#0.0005,#500.0|4:2345=\"test\"", queryConcept2.getAttrMap());
 		assertEquals(groupedAttributesMap, queryConcept2.getGroupedAttributesMap());
 	}
 

--- a/src/test/java/org/snomed/snowstorm/core/data/services/SemanticIndexUpdateServiceTest.java
+++ b/src/test/java/org/snomed/snowstorm/core/data/services/SemanticIndexUpdateServiceTest.java
@@ -1146,8 +1146,10 @@ class SemanticIndexUpdateServiceTest extends AbstractTest {
 
 		// add a value with decimal for 396070080 attribute
 		concepts.add(new Concept("34020009").addRelationship(new Relationship(UUID.randomUUID().toString(), ISA, "34020006"))
-				.addRelationship(new Relationship("3332955025", null, true, "900000000000207008",
-						"34020009", "#100.000005", 1, "396070080", "900000000000011006", "900000000000451002")));
+				.addRelationship(new Relationship("34900001020", null, true, "900000000000207008",
+						"34020009", "#100.000005", 1, "396070080", "900000000000011006", "900000000000451002"))
+				.addRelationship(new Relationship("34900002020", null, true, "900000000000207008",
+						"34020009", "#0.0005", 1, "396070080", "900000000000011006", "900000000000451002")));
 		// Use low level component save to prevent effectiveTimes being stripped by concept service
 		simulateRF2Import(path, concepts);
 
@@ -1189,14 +1191,15 @@ class SemanticIndexUpdateServiceTest extends AbstractTest {
 		// range queries
 		assertEquals(2, queryService.search(queryService.createQueryBuilder(false).ecl("*:396070080 >= #50"), path, PAGE_REQUEST).getTotalElements());
 		assertEquals(1, queryService.search(queryService.createQueryBuilder(false).ecl("*:396070080 > #50"), path, PAGE_REQUEST).getTotalElements());
-		assertEquals(0, queryService.search(queryService.createQueryBuilder(false).ecl("*:396070080 < #50"), path, PAGE_REQUEST).getTotalElements());
-		assertEquals(1, queryService.search(queryService.createQueryBuilder(false).ecl("*:396070080 <= #50"), path, PAGE_REQUEST).getTotalElements());
+		assertEquals(1, queryService.search(queryService.createQueryBuilder(false).ecl("*:396070080 < #50"), path, PAGE_REQUEST).getTotalElements());
+		assertEquals(2, queryService.search(queryService.createQueryBuilder(false).ecl("*:396070080 <= #50"), path, PAGE_REQUEST).getTotalElements());
 
 		// make sure range query is not done alphabetically but based on the number value
 		assertEquals(2, queryService.search(queryService.createQueryBuilder(false).ecl("*:396070080 >= #6"), path, PAGE_REQUEST).getTotalElements());
 
 		// Not equal to query
-		assertEquals(0, queryService.search(queryService.createQueryBuilder(false).ecl("<<34020009:396070080 != #100.000005"), path, PAGE_REQUEST).getTotalElements());
+		assertEquals(1, queryService.search(queryService.createQueryBuilder(false).ecl("<<34020009:396070080 = #100.000005"), path, PAGE_REQUEST).getTotalElements());
+		assertEquals(1, queryService.search(queryService.createQueryBuilder(false).ecl("<<34020009: [1..1] * = #0.0005"), path, PAGE_REQUEST).getTotalElements());
 		assertEquals(1, queryService.search(queryService.createQueryBuilder(false).ecl("*:396070080 != #50"), path, PAGE_REQUEST).getTotalElements());
 		assertEquals(2, queryService.search(queryService.createQueryBuilder(false).ecl("*:396070080 != #10"), path, PAGE_REQUEST).getTotalElements());
 		assertEquals(0, queryService.search(queryService.createQueryBuilder(false).ecl("*:396070081 != \"123test\""), path, PAGE_REQUEST).getTotalElements());


### PR DESCRIPTION
This fixes the way that decimal numbers are stored in the Snowstorm semantic index, that is used for ECL queries.

Previously concrete domain numbers like `0.00005` were stored in the index in scientific notation like `5.0E-4`. This causes ECL queries that use that number to throw an exception.

Unit tests are included that test:
- the serialisation and deserialisation of this number
- An ECL query using this number that previously failed when the format was bad
