### PR TITLE
Documentation: Fix params name in description search Swagger docs

### DIFF
--- a/src/main/java/org/snomed/snowstorm/rest/DescriptionController.java
+++ b/src/main/java/org/snomed/snowstorm/rest/DescriptionController.java
@@ -67,16 +67,16 @@ public class DescriptionController {
 			@Deprecated
 			@RequestParam(required = false) String semanticTag,
 
-			@Parameter(name = "Set of semantic tags.")
+			@Parameter(description = "Set of semantic tags.")
 			@RequestParam(required = false) Set<String> semanticTags,
 
-			@Parameter(name = "Set of description language reference sets. The description must be preferred in at least one of these to match.")
+			@Parameter(description = "Set of description language reference sets. The description must be preferred in at least one of these to match.")
 			@RequestParam(required = false) Set<Long> preferredIn,
 
-			@Parameter(name = "Set of description language reference sets. The description must be acceptable in at least one of these to match.")
+			@Parameter(description = "Set of description language reference sets. The description must be acceptable in at least one of these to match.")
 			@RequestParam(required = false) Set<Long> acceptableIn,
 
-			@Parameter(name = "Set of description language reference sets. The description must be preferred OR acceptable in at least one of these to match.")
+			@Parameter(description = "Set of description language reference sets. The description must be preferred OR acceptable in at least one of these to match.")
 			@RequestParam(required = false) Set<Long> preferredOrAcceptableIn,
 
 			@RequestParam(required = false) Boolean conceptActive,


### PR DESCRIPTION
In **Descriptions** section, some swagger params names are not working well. I changed _name_ field by _description_. 