### PR TITLE
ISTO-107 Fix loading LOINC 2.73 and above

### DIFF
--- a/docs/using-the-fhir-api.md
+++ b/docs/using-the-fhir-api.md
@@ -13,9 +13,8 @@ _Please Note: The native Snowstorm API must be used to create code systems and i
 The LOINC code system is supported. 
 A LOINC package can be imported using the [HAPI-FHIR CLI tool](https://hapifhir.io/hapi-fhir/docs/tools/hapi_fhir_cli.html) with the following command:
 ```
-hapi-fhir-cli upload-terminology -d Loinc_2.72.zip -v r4 -t http://localhost:8080/fhir -u http://loinc.org
+hapi-fhir-cli upload-terminology -d Loinc_2.76.zip -v r4 -t http://localhost:8080/fhir -u http://loinc.org
 ```
-*N.B. The new file naming since Loinc 2.73 is not working yet.*
 
 ### ICD-10 (International Version)
 The international version of ICD-10 is supported. This distribution uses the CLAML format. 

--- a/src/main/resources/ca/uhn/fhir/jpa/term/loinc/loincupload.properties
+++ b/src/main/resources/ca/uhn/fhir/jpa/term/loinc/loincupload.properties
@@ -1,0 +1,5 @@
+# This property informs the HAPI-FHIR LOINC package loader of the location of the hierarchy file within the LOINC package
+# For LOINC v2.72 and earlier:
+# loinc.hierarchy.file=AccessoryFiles/MultiAxialHierarchy/MultiAxialHierarchy.csv
+# For LOINC 2.73 and above:
+loinc.hierarchy.file=AccessoryFiles/ComponentHierarchyBySystem/ComponentHierarchyBySystem.csv


### PR DESCRIPTION
This PR adds config that is picked up by the HAPI FHIR library so that the new LOINC zip entry file naming is used, enabling the latest LOINC packages to be loaded.
This change has already been tested today, see jira ticket for details.