### PR TITLE
MAINT-2452

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/services/AxiomConversionService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/AxiomConversionService.java
@@ -61,11 +61,25 @@ public class AxiomConversionService {
 		AxiomRelationshipConversionService conversionService = setupConversionService(branchPath);
 		for (Concept concept : concepts) {
 			for (Axiom axiom : concept.getClassAxioms()) {
-				String owlExpression = conversionService.convertRelationshipsToAxiom(mapFromInternalRelationshipType(concept.getConceptId(), axiom.getDefinitionStatusId(), axiom.getRelationships(), true));
+				String owlExpression;
+				ReferenceSetMember referenceSetMember = axiom.getReferenceSetMember();
+				if (!axiom.isActive() && referenceSetMember != null) {
+					owlExpression = referenceSetMember.getAdditionalField(ReferenceSetMember.OwlExpressionFields.OWL_EXPRESSION);
+				} else {
+					owlExpression = conversionService.convertRelationshipsToAxiom(mapFromInternalRelationshipType(concept.getConceptId(), axiom.getDefinitionStatusId(), axiom.getRelationships(), true));
+				}
+
 				axiom.setReferenceSetMember(createMember(concept, axiom, owlExpression));
 			}
 			for (Axiom gciAxiom : concept.getGciAxioms()) {
-				String owlExpression = conversionService.convertRelationshipsToAxiom(mapFromInternalRelationshipType(concept.getConceptId(), gciAxiom.getDefinitionStatusId(), gciAxiom.getRelationships(), false));
+				String owlExpression;
+				ReferenceSetMember referenceSetMember = gciAxiom.getReferenceSetMember();
+				if (!gciAxiom.isActive() && referenceSetMember != null) {
+					owlExpression = referenceSetMember.getAdditionalField(ReferenceSetMember.OwlExpressionFields.OWL_EXPRESSION);
+				} else {
+					owlExpression = conversionService.convertRelationshipsToAxiom(mapFromInternalRelationshipType(concept.getConceptId(), gciAxiom.getDefinitionStatusId(), gciAxiom.getRelationships(), false));
+				}
+
 				gciAxiom.setReferenceSetMember(createMember(concept, gciAxiom, owlExpression));
 			}
 		}


### PR DESCRIPTION
If an Axiom's OWL Expression is incorrectly back to front (i.e. parent -> child instead of child -> parent), an update to the Concept will result in the OWL Expression being partly fixed (i.e. child -> child), resulting in a Concept being its own ancestor.