### PR TITLE
Add reindex of branch-review to elasticsearch upgrade guide

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.snomed</groupId>
 		<artifactId>snomed-parent-bom</artifactId>
-		<version>3.7.1</version>
+		<version>3.8.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<description>SNOMED CT Terminology Server Using Elasticsearch</description>
 
 	<artifactId>snowstorm</artifactId>
-	<version>10.5.0</version>
+	<version>10.6.0-SNAPSHOT</version>
 	<parent>
 		<groupId>org.snomed</groupId>
 		<artifactId>snomed-parent-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.snomed</groupId>
 		<artifactId>snomed-parent-bom</artifactId>
-		<version>3.8.0-SNAPSHOT</version>
+		<version>3.9.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,8 @@
 
 	<properties>
 		<packageName>${project.artifactId}</packageName>
+		<!-- BOM Override -->
+		<jena_version>4.9.0</jena_version>
 		<!--
 		Current Elasticsearch _Server_ version is 8.11.1
 		N.B. Remember to keep TestConfig.ELASTIC_SEARCH_SERVER_VERSION and getting-started guide updated.
@@ -27,6 +29,18 @@
 	</properties>
 
 	<dependencies>
+		<!-- BOM Override -->
+		<dependency>
+			<groupId>org.apache.jena</groupId>
+			<artifactId>jena-core</artifactId>
+			<version>${jena_version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.jena</groupId>
+			<artifactId>jena-arq</artifactId>
+			<version>${jena_version}</version>
+		</dependency>
+
 		<dependency>
 			<!-- Branching and Version Control on top of Elasticsearch -->
 			<groupId>io.kaicode</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<description>SNOMED CT Terminology Server Using Elasticsearch</description>
 
 	<artifactId>snowstorm</artifactId>
-	<version>10.6.1</version>
+	<version>10.7.0-SNAPSHOT</version>
 	<parent>
 		<groupId>org.snomed</groupId>
 		<artifactId>snomed-parent-bom</artifactId>

--- a/src/main/java/org/snomed/snowstorm/core/data/domain/Concepts.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/domain/Concepts.java
@@ -14,6 +14,7 @@ public class Concepts {
 	public static final String CORE_MODULE = "900000000000207008";
 	public static final String MODEL_MODULE = "900000000000012004";
 	public static final String ICD10_MODULE = "449080006";
+	public static final String ICD11_MODULE = "1204363008";
 	public static final String COMMON_FRENCH_MODULE = "11000241103";
 	public static final String MODULE = "900000000000443000";
 

--- a/src/main/java/org/snomed/snowstorm/core/data/services/ConceptService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/ConceptService.java
@@ -870,6 +870,17 @@ public class ConceptService extends ComponentService {
 		final Branch sourceBranch = branchService.findBranchOrThrow(sourceBranchPath, true);
 		final Branch destinationBranch = branchService.findBranchOrThrow(destinationBranchPath, true);
 
+		CodeSystem codeSystem = codeSystemService.findClosestCodeSystemUsingAnyBranch(destinationBranchPath, false);
+		if (codeSystem != null) {
+			List<CodeSystemVersion> codeSystemVersions = codeSystemService.findAllVersions(codeSystem.getShortName(), true, true);
+			String branchPath = destinationBranch.getPath();
+			for (CodeSystemVersion codeSystemVersion : codeSystemVersions) {
+				if (Objects.equals(branchPath, codeSystemVersion.getBranchPath())) {
+					throw new ServiceException("Cannot donate concepts from " + sourceBranchPath + " to versioned " + destinationBranchPath);
+				}
+			}
+		}
+
 		if (getDefaultModuleId(sourceBranch).equals(getDefaultModuleId(destinationBranch))) {
 			throw new ServiceException("Cannot donate concepts from " + sourceBranchPath + " to " + destinationBranchPath + " as they are from the same module: " + getDefaultModuleId(sourceBranch));
 		}

--- a/src/main/java/org/snomed/snowstorm/core/data/services/DescriptionService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/DescriptionService.java
@@ -943,7 +943,7 @@ public class DescriptionService extends ComponentService {
 		}
 	}
 
-	private List<String> analyze(String text, StandardAnalyzer analyzer) {
+	public static List<String> analyze(String text, StandardAnalyzer analyzer) {
 		List<String> result = new ArrayList<>();
 		try {
 			TokenStream tokenStream = analyzer.tokenStream("contents", text);
@@ -953,12 +953,13 @@ public class DescriptionService extends ComponentService {
 				result.add(attr.toString());
 			}
 		} catch (IOException e) {
-			logger.error("Failed to analyze text {}", text, e);
+			LoggerFactory.getLogger(DescriptionService.class)
+					.error("Failed to analyze text {}", text, e);
 		}
 		return result;
 	}
 
-	private String constructSimpleQueryString(String searchTerm) {
+	public static String constructSimpleQueryString(String searchTerm) {
 		return (searchTerm.trim().replace(" ", "* ") + "*").replace("**", "*");
 	}
 
@@ -1000,7 +1001,7 @@ public class DescriptionService extends ComponentService {
 		return regexBuilder.toString();
 	}
 
-	private String constructSearchTerm(List<String> tokens) {
+	public static String constructSearchTerm(List<String> tokens) {
 		StringBuilder builder = new StringBuilder();
 		for (String token : tokens) {
 			builder.append(token);

--- a/src/main/java/org/snomed/snowstorm/core/data/services/ModuleDependencyService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/ModuleDependencyService.java
@@ -42,7 +42,7 @@ public class ModuleDependencyService extends ComponentService {
 	
 	public static final Set<String> CORE_MODULES = Set.of(Concepts.CORE_MODULE, Concepts.MODEL_MODULE);
 	
-	public Set<String> SI_MODULES = new HashSet<>(Set.of(Concepts.CORE_MODULE, Concepts.MODEL_MODULE, Concepts.ICD10_MODULE));
+	public Set<String> SI_MODULES = new HashSet<>(Set.of(Concepts.CORE_MODULE, Concepts.MODEL_MODULE, Concepts.ICD10_MODULE, Concepts.ICD11_MODULE));
 	
 	@Autowired
 	private BranchService branchService;
@@ -94,9 +94,12 @@ public class ModuleDependencyService extends ComponentService {
 			cacheValidAt = currentTime;
 			logger.info("MDR cache of International Modules refreshed for HEAD time: {}", currentTime);
 			
-			//During unit tests, or in non-standard installations we might not see the ICD-10 Module
+			//During unit tests, or in non-standard installations we might not see the ICD-10 and ICD-11 Modules
 			if (!cachedInternationalModules.contains(Concepts.ICD10_MODULE)) {
 				SI_MODULES.remove(Concepts.ICD10_MODULE);
+			}
+			if (!cachedInternationalModules.contains(Concepts.ICD11_MODULE)) {
+				SI_MODULES.remove(Concepts.ICD11_MODULE);
 			}
 			
 			derivativeModules = cachedInternationalModules.stream()

--- a/src/main/java/org/snomed/snowstorm/fhir/services/FHIRConceptService.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/FHIRConceptService.java
@@ -4,7 +4,6 @@ import ca.uhn.fhir.jpa.entity.TermCodeSystemVersion;
 import ca.uhn.fhir.jpa.entity.TermConcept;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import com.google.common.collect.Iterables;
-
 import org.hl7.fhir.r4.model.CodeSystem;
 import org.hl7.fhir.r4.model.CodeType;
 import org.slf4j.Logger;
@@ -19,10 +18,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
-import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -182,6 +182,7 @@ public class FHIRConceptService {
 	public Page<FHIRConcept> findConcepts(BoolQuery.Builder fhirConceptQuery, PageRequest pageRequest) {
 		NativeQuery searchQuery = new NativeQueryBuilder()
 				.withQuery(fhirConceptQuery.build()._toQuery())
+				.withSort(Sort.by(FHIRConcept.Fields.CODE))
 				.withPageable(pageRequest)
 				.build();
 		searchQuery.setTrackTotalHits(true);
@@ -189,9 +190,10 @@ public class FHIRConceptService {
 		return toPage(elasticsearchOperations.search(searchQuery, FHIRConcept.class), pageRequest);
 	}
 
-	public SearchAfterPage<String> findConceptCodes(BoolQuery.Builder fhirConceptQuery, PageRequest pageRequest) {
+	public SearchAfterPage<String> findConceptCodes(BoolQuery fhirConceptQuery, PageRequest pageRequest) {
 		NativeQuery searchQuery = new NativeQueryBuilder()
-				.withQuery(fhirConceptQuery.build()._toQuery())
+				.withQuery(fhirConceptQuery._toQuery())
+				.withSort(Sort.by(FHIRConcept.Fields.CODE))
 				.withPageable(pageRequest)
 				.build();
 		searchQuery.setTrackTotalHits(true);

--- a/src/main/java/org/snomed/snowstorm/fhir/services/FHIRConceptService.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/FHIRConceptService.java
@@ -182,7 +182,7 @@ public class FHIRConceptService {
 	public Page<FHIRConcept> findConcepts(BoolQuery.Builder fhirConceptQuery, PageRequest pageRequest) {
 		NativeQuery searchQuery = new NativeQueryBuilder()
 				.withQuery(fhirConceptQuery.build()._toQuery())
-				.withSort(Sort.by(FHIRConcept.Fields.CODE))
+				.withSort(Sort.by(FHIRConcept.Fields.DISPLAY_LENGTH, FHIRConcept.Fields.CODE))
 				.withPageable(pageRequest)
 				.build();
 		searchQuery.setTrackTotalHits(true);


### PR DESCRIPTION
The upgrade guide did not include instructions for reindexing branch-review index to change the field type for lastUpdate to long. This meant branch merge-reviews failed with an internal server error.

This PR updates the docs to include the required steps to reindex branch-review to allow merge-reviews without errors.