### PR TITLE
Fixes #638 ISTO-125 LOINC pagination fix.

### DIFF
--- a/src/main/java/org/snomed/snowstorm/fhir/services/FHIRConceptService.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/FHIRConceptService.java
@@ -4,7 +4,6 @@ import ca.uhn.fhir.jpa.entity.TermCodeSystemVersion;
 import ca.uhn.fhir.jpa.entity.TermConcept;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import com.google.common.collect.Iterables;
-
 import org.hl7.fhir.r4.model.CodeSystem;
 import org.hl7.fhir.r4.model.CodeType;
 import org.slf4j.Logger;
@@ -19,10 +18,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
-import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -182,6 +182,7 @@ public class FHIRConceptService {
 	public Page<FHIRConcept> findConcepts(BoolQuery.Builder fhirConceptQuery, PageRequest pageRequest) {
 		NativeQuery searchQuery = new NativeQueryBuilder()
 				.withQuery(fhirConceptQuery.build()._toQuery())
+				.withSort(Sort.by(FHIRConcept.Fields.CODE))
 				.withPageable(pageRequest)
 				.build();
 		searchQuery.setTrackTotalHits(true);
@@ -189,9 +190,10 @@ public class FHIRConceptService {
 		return toPage(elasticsearchTemplate.search(searchQuery, FHIRConcept.class), pageRequest);
 	}
 
-	public SearchAfterPage<String> findConceptCodes(BoolQuery.Builder fhirConceptQuery, PageRequest pageRequest) {
+	public SearchAfterPage<String> findConceptCodes(BoolQuery fhirConceptQuery, PageRequest pageRequest) {
 		NativeQuery searchQuery = new NativeQueryBuilder()
-				.withQuery(fhirConceptQuery.build()._toQuery())
+				.withQuery(fhirConceptQuery._toQuery())
+				.withSort(Sort.by(FHIRConcept.Fields.CODE))
 				.withPageable(pageRequest)
 				.build();
 		searchQuery.setTrackTotalHits(true);

--- a/src/main/java/org/snomed/snowstorm/fhir/services/FHIRValueSetService.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/FHIRValueSetService.java
@@ -279,7 +279,7 @@ public class FHIRValueSetService {
 			// FHIR Concept Expansion (non-SNOMED)
 			String sortField = filter != null ? "displayLen" : "code";
 			pageRequest = PageRequest.of(pageRequest.getPageNumber(), pageRequest.getPageSize(), Sort.Direction.ASC, sortField);
-			BoolQuery.Builder fhirConceptQuery = getFhirConceptQuery(codeSelectionCriteria, filter);
+			BoolQuery fhirConceptQuery = getFhirConceptQuery(codeSelectionCriteria, filter).build();
 
 			int offsetRequested = (int) pageRequest.getOffset();
 			int limitRequested = (int) (pageRequest.getOffset() + pageRequest.getPageSize());
@@ -314,14 +314,16 @@ public class FHIRValueSetService {
 					conceptsToLoad = new ArrayList<>();
 				}
 				if (!conceptsToLoad.isEmpty()) {
-					fhirConceptQuery.must(termsQuery(FHIRConcept.Fields.CODE, conceptsToLoad));
-					conceptsPage = conceptService.findConcepts(fhirConceptQuery, LARGE_PAGE);
+					BoolQuery.Builder conceptsToLoadQuery = bool()
+							.must(fhirConceptQuery._toQuery())
+							.must(termsQuery(FHIRConcept.Fields.CODE, conceptsToLoad));
+					conceptsPage = conceptService.findConcepts(conceptsToLoadQuery, LARGE_PAGE);
 					conceptsPage = new PageImpl<>(conceptsPage.getContent(), pageRequest, totalResults);
 				} else {
 					conceptsPage = new PageImpl<>(new ArrayList<>(), pageRequest, totalResults);
 				}
 			} else {
-				conceptsPage = conceptService.findConcepts(fhirConceptQuery, pageRequest);
+				conceptsPage = conceptService.findConcepts(bool().must(fhirConceptQuery._toQuery()), pageRequest);
 			}
 		}
 


### PR DESCRIPTION
This fixes a bug in the Snowstorm FHIR API where it's not possible to paginate beyond a 10,000 code offset. 

This regression was introduced during the Elasticsearch 8 upgrade last year. It is caused by the Spring Boot Elasticsearch 8 library not allowing queries to be reused.

Local testing shows that these changes fix the bug. I have also added result sorting based on code to ensure consistent pagination with different page sizes which makes testing easier.

This screenshot shows using a very large offset to a page with the last three LOINC codes:
<img width="801" alt="Screenshot 2024-11-13 at 14 27 59" src="https://github.com/user-attachments/assets/8514e330-76a6-4217-a172-4670b01f24fa">

Performance is quite poor because with Elasticsearch we can not jump to an offset beyond 10k, we have to scroll through the results. The search-after token technique would solve this but it's not compatible with the FHIR API.