### PR TITLE
Fix #656 ISTO-132 FHIR lookup by CodeSystem id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<description>SNOMED CT Terminology Server Using Elasticsearch</description>
 
 	<artifactId>snowstorm</artifactId>
-	<version>10.7.0</version>
+	<version>10.8.0-SNAPSHOT</version>
 	<parent>
 		<groupId>org.snomed</groupId>
 		<artifactId>snomed-parent-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.snomed</groupId>
 		<artifactId>snomed-parent-bom</artifactId>
-		<version>3.9.0</version>
+		<version>3.10.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/src/main/java/org/snomed/snowstorm/core/data/domain/Concepts.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/domain/Concepts.java
@@ -14,6 +14,7 @@ public class Concepts {
 	public static final String CORE_MODULE = "900000000000207008";
 	public static final String MODEL_MODULE = "900000000000012004";
 	public static final String ICD10_MODULE = "449080006";
+	public static final String ICD11_MODULE = "1204363008";
 	public static final String COMMON_FRENCH_MODULE = "11000241103";
 	public static final String MODULE = "900000000000443000";
 

--- a/src/main/java/org/snomed/snowstorm/core/data/services/ModuleDependencyService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/ModuleDependencyService.java
@@ -42,7 +42,7 @@ public class ModuleDependencyService extends ComponentService {
 	
 	public static final Set<String> CORE_MODULES = Set.of(Concepts.CORE_MODULE, Concepts.MODEL_MODULE);
 	
-	public Set<String> SI_MODULES = new HashSet<>(Set.of(Concepts.CORE_MODULE, Concepts.MODEL_MODULE, Concepts.ICD10_MODULE));
+	public Set<String> SI_MODULES = new HashSet<>(Set.of(Concepts.CORE_MODULE, Concepts.MODEL_MODULE, Concepts.ICD10_MODULE, Concepts.ICD11_MODULE));
 	
 	@Autowired
 	private BranchService branchService;
@@ -94,9 +94,12 @@ public class ModuleDependencyService extends ComponentService {
 			cacheValidAt = currentTime;
 			logger.info("MDR cache of International Modules refreshed for HEAD time: {}", currentTime);
 			
-			//During unit tests, or in non-standard installations we might not see the ICD-10 Module
+			//During unit tests, or in non-standard installations we might not see the ICD-10 and ICD-11 Modules
 			if (!cachedInternationalModules.contains(Concepts.ICD10_MODULE)) {
 				SI_MODULES.remove(Concepts.ICD10_MODULE);
+			}
+			if (!cachedInternationalModules.contains(Concepts.ICD11_MODULE)) {
+				SI_MODULES.remove(Concepts.ICD11_MODULE);
 			}
 			
 			derivativeModules = cachedInternationalModules.stream()

--- a/src/main/java/org/snomed/snowstorm/core/pojo/LanguageDialect.java
+++ b/src/main/java/org/snomed/snowstorm/core/pojo/LanguageDialect.java
@@ -23,8 +23,16 @@ public class LanguageDialect implements Serializable {
 		this.languageReferenceSet = languageReferenceSet;
 	}
 
+	public void setLanguageCode(String languageCode) {
+		this.languageCode = languageCode;
+	}
+
 	public String getLanguageCode() {
 		return languageCode;
+	}
+
+	public void setLanguageReferenceSet(Long languageReferenceSet) {
+		this.languageReferenceSet = languageReferenceSet;
 	}
 
 	public Long getLanguageReferenceSet() {

--- a/src/main/java/org/snomed/snowstorm/fhir/services/FHIRHelper.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/FHIRHelper.java
@@ -38,7 +38,7 @@ public class FHIRHelper implements FHIRConstants {
 
 	private static final Pattern SNOMED_URI_MODULE_PATTERN = Pattern.compile("http://snomed.info/x?sct/(\\d+)");
 	private static final Pattern SNOMED_URI_MODULE_AND_VERSION_PATTERN = Pattern.compile("http://snomed.info/x?sct/(\\d+)/version/([\\d]{8})");
-	private static final Pattern SCT_ID_PATTERN = Pattern.compile("sct_(\\d)+_(\\d){8}");
+	private static final Pattern SCT_ID_PATTERN = Pattern.compile("sct_(\\d+)_(\\d{8})");
 
 	private static final SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd"); // TODO: This is not thread safe!
 
@@ -348,6 +348,7 @@ public class FHIRHelper implements FHIRConstants {
 			}
 		}
 		if (systemId != null) {
+			codeSystemParams.setId(systemId);
 			if (codeSystemParams.isSnomed()) {
 				Matcher idMatcher = SCT_ID_PATTERN.matcher(systemId);
 				if (!idMatcher.matches()) {

--- a/src/main/java/org/snomed/snowstorm/rest/ControllerHelper.java
+++ b/src/main/java/org/snomed/snowstorm/rest/ControllerHelper.java
@@ -38,6 +38,7 @@ import static org.snomed.snowstorm.config.Config.DEFAULT_LANGUAGE_DIALECTS;
 public class ControllerHelper {
 
 	private static final Pattern LANGUAGE_PATTERN = Pattern.compile("([a-z]{2})");
+	private static final Pattern LANGUAGE_AND_REGIONAL_DIALECT_PATTERN = Pattern.compile("([a-z]{2})-\\d+$");
 	private static final Pattern LANGUAGE_AND_REFSET_PATTERN = Pattern.compile("([a-z]{2})-x-(" + IdentifierService.SCTID_PATTERN + ")");
 	private static final Pattern LANGUAGE_AND_DIALECT_PATTERN = Pattern.compile("([a-z]{2})-([a-z]{2})");
 	private static final Pattern LANGUAGE_AND_DIALECT_AND_CONTEXT_PATTERN = Pattern.compile("([a-z]{2})-([a-z]{2})-([a-z]+)");
@@ -181,6 +182,8 @@ public class ControllerHelper {
 
 			Matcher matcher = LANGUAGE_PATTERN.matcher(value);
 			if (matcher.matches()) {
+				languageCode = matcher.group(1);
+			} else if ((matcher = LANGUAGE_AND_REGIONAL_DIALECT_PATTERN.matcher(value)).matches()) {
 				languageCode = matcher.group(1);
 			} else if ((matcher = LANGUAGE_AND_REFSET_PATTERN.matcher(value)).matches()) {
 				languageCode = matcher.group(1);

--- a/src/main/java/org/snomed/snowstorm/rest/config/RestControllerAdvice.java
+++ b/src/main/java/org/snomed/snowstorm/rest/config/RestControllerAdvice.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -70,7 +71,7 @@ public class RestControllerAdvice {
 		return result;
 	}
 
-	@ExceptionHandler({BranchNotFoundException.class, NotFoundException.class})
+	@ExceptionHandler({BranchNotFoundException.class, NotFoundException.class, NoResourceFoundException.class})
 	@ResponseStatus(HttpStatus.NOT_FOUND)
 	@ResponseBody
 	public Map<String,Object> handleNotFoundException(Exception exception) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -221,13 +221,14 @@ codesystem.config.SNOMEDCT-BE=Belgium Edition|11000172109|be|Belgian Federal Pub
 codesystem.config.SNOMEDCT-CA=Canadian English Edition|20621000087109|ca|Canada Health Infoway
 codesystem.config.SNOMEDCT-CAF=Canadian French Edition|20611000087101|ca|Canada Health Infoway
 codesystem.config.SNOMEDCT-CH=Swiss Edition|2011000195101|en|eHealth Suisse
+codesystem.config.SNOMEDCT-CZ=Czech Republic Edition|11000279109|cz|Ministry of Health, Czech Republic
 codesystem.config.SNOMEDCT-DE=German Edition|11000274103|de|Bundesinstitut fÃ¼r Arzneimittel und Medizinprodukte, BfArM
 codesystem.config.SNOMEDCT-DK=Danish Edition|554471000005108|dk|Danish Health Data Authority
 codesystem.config.SNOMEDCT-EE=Estonian Edition|11000181102|ee|Estonia Health and Welfare Information Systems Centre
 codesystem.config.SNOMEDCT-ES=Spanish Edition|449081005|es|SNOMED International
 codesystem.config.SNOMEDCT-ES-SNS=Spanish National Edition|900000001000122104|es|Ministerio de Sanidad
 codesystem.config.SNOMEDCT-FI=Finland Edition|11000229106|fi|Finland National Institute for Health and Welfare
-codesystem.config.SNOMEDCT-FR=French Edition|11000315107|fr|Agence du Numérique en Santé
+codesystem.config.SNOMEDCT-FR=French Edition|11000315107|fr|Agence du NumÃ©rique en SantÃ©
 codesystem.config.SNOMEDCT-IE=Irish Edition|11000220105|ie|Department of Health / eHealth Ireland
 codesystem.config.SNOMEDCT-IN=Indian Edition|1121000189102|in|eHealth Division, MoH&FW
 codesystem.config.SNOMEDCT-NL=Netherlands Edition|11000146104|nl|National IT Institute for Healthcare in the Netherlands (Nicitz)
@@ -371,17 +372,17 @@ search.description.semantic.tag.aggregation.size=200
 #   All characters will be converted to lowercase for this part of the index.
 #   Tool for UTF-16 conversion here https://www.branah.com/unicode-converter
 # ----------------------------------------
-# Danish æøå
+# Danish Ã¦Ã¸Ã¥
 search.language.charactersNotFolded.da=\u00e6\u00f8\u00e5
-# Finnish åäö
+# Finnish Ã¥Ã¤Ã¶
 search.language.charactersNotFolded.fi=\u00e5\u00e4\u00f6
 # French - No diacritic characters
 search.language.charactersNotFolded.fr=
-# Norwegian æøå
+# Norwegian Ã¦Ã¸Ã¥
 search.language.charactersNotFolded.no=\u00e6\u00f8\u00e5
 # Spanish - all characters folded to allow simple form to match
 search.language.charactersNotFolded.es=
-# Swedish åäö
+# Swedish Ã¥Ã¤Ã¶
 search.language.charactersNotFolded.sv=\u00e5\u00e4\u00f6
 
 

--- a/src/test/java/org/snomed/snowstorm/fhir/services/FHIRCodeSystemProviderInstancesTest.java
+++ b/src/test/java/org/snomed/snowstorm/fhir/services/FHIRCodeSystemProviderInstancesTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class FHIRCodeSystemProviderInstancesTest extends AbstractFHIRTest {
 
 	@Test
-	void testCodeSystemRecovery() {
+	void testCodeSystemList() {
 		String url = "http://localhost:" + port + "/fhir/CodeSystem";
 		ResponseEntity<String> response = this.restTemplate.exchange(url, HttpMethod.GET, defaultRequestEntity, String.class);
 		expectResponse(response, 200);
@@ -27,7 +27,7 @@ class FHIRCodeSystemProviderInstancesTest extends AbstractFHIRTest {
 	}
 	
 	@Test
-	void testCodeSystemRecoverySorted() {
+	void testCodeSystemListSorted() {
 		String url = "http://localhost:" + port + "/fhir/CodeSystem?_sort=title,-date";
 		ResponseEntity<String> response = this.restTemplate.exchange(url, HttpMethod.GET, defaultRequestEntity, String.class);
 		expectResponse(response, 200);
@@ -42,10 +42,10 @@ class FHIRCodeSystemProviderInstancesTest extends AbstractFHIRTest {
 	}
 	
 	@Test
-	void testCodeSystemRecoverySortedExpectedFail() {
+	void testCodeSystemListSortedExpectedFail() {
 		String url = "http://localhost:" + port + "/fhir/CodeSystem?_sort=foo,-bar";
 		ResponseEntity<String> response = this.restTemplate.exchange(url, HttpMethod.GET, defaultRequestEntity, String.class);
 		expectResponse(response, 400);
 	}
-	
+
 }

--- a/src/test/java/org/snomed/snowstorm/fhir/services/FHIRCodeSystemProviderLookupTest.java
+++ b/src/test/java/org/snomed/snowstorm/fhir/services/FHIRCodeSystemProviderLookupTest.java
@@ -8,12 +8,43 @@ import static org.junit.jupiter.api.Assertions.*;
 class FHIRCodeSystemProviderLookupTest extends AbstractFHIRTest {
 
 	@Test
-	void testSingleConceptRecovery() {
+	void testSingleConceptLookupDefaultSnomedVersion() {
 		String url = "http://localhost:" + port + "/fhir/CodeSystem/$lookup?system=http://snomed.info/sct&code=" + sampleSCTID + "&_format=json";
 		Parameters p = getParameters(url);
 		assertNotNull(p);
+		assertEquals("http://snomed.info/sct", p.getParameterValue("system").toString());
+		assertEquals("http://snomed.info/sct/900000000000207008/version/20190131", p.getParameterValue("version").toString());
+	}
+
+	@Test
+	void testSingleConceptLookupInternationalSnomedVersion() {
+		String url = "http://localhost:" + port + "/fhir/CodeSystem/$lookup?system=http://snomed.info/sct" +
+				"&version=http://snomed.info/sct/900000000000207008&code=" + sampleSCTID + "&_format=json";
+		Parameters p = getParameters(url);
+		assertNotNull(p);
+		assertEquals("http://snomed.info/sct", p.getParameterValue("system").toString());
+		assertEquals("http://snomed.info/sct/900000000000207008/version/20190131", p.getParameterValue("version").toString());
+	}
+
+	@Test
+	void testSingleConceptLookupExtensionSnomedVersionByVersionParam() {
+		String url = "http://localhost:" + port + "/fhir/CodeSystem/$lookup?system=http://snomed.info/sct" +
+				"&version=http://snomed.info/sct/1234000008&code=" + sampleSCTID + "&_format=json";
+		Parameters p = getParameters(url);
+		assertNotNull(p);
+		assertEquals("http://snomed.info/sct", p.getParameterValue("system").toString());
+		assertEquals("http://snomed.info/sct/1234000008/version/20190731", p.getParameterValue("version").toString());
 	}
 	
+	@Test
+	void testSingleConceptLookupExtensionSnomedVersionByInstanceUrl() {
+		String url = "http://localhost:" + port + "/fhir/CodeSystem/sct_1234000008_20190731/$lookup?code=" + sampleSCTID + "&_format=json";
+		Parameters p = getParameters(url);
+		assertNotNull(p);
+		assertEquals("http://snomed.info/sct", p.getParameterValue("system").toString());
+		assertEquals("http://snomed.info/sct/1234000008/version/20190731", p.getParameterValue("version").toString());
+	}
+
 	@Test
 	void testSinglePropertiesRecovery() {
 		String url = "http://localhost:" + port + "/fhir/CodeSystem/$lookup?system=http://snomed.info/sct&code=" + sampleSCTID + "&property=normalForm&_format=json";

--- a/src/test/java/org/snomed/snowstorm/fhir/services/FHIRHelperTest.java
+++ b/src/test/java/org/snomed/snowstorm/fhir/services/FHIRHelperTest.java
@@ -1,0 +1,46 @@
+package org.snomed.snowstorm.fhir.services;
+
+import org.junit.jupiter.api.Test;
+import org.snomed.snowstorm.fhir.pojo.FHIRCodeSystemVersionParams;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FHIRHelperTest {
+
+	@Test
+	void testGetVersionParamsSCT() {
+		FHIRCodeSystemVersionParams versionParams =
+				FHIRHelper.getCodeSystemVersionParams(null, "http://snomed.info/sct", null, null);
+		assertTrue(versionParams.isSnomed());
+		assertNull(versionParams.getSnomedModule());
+		assertNull(versionParams.getVersion());
+	}
+
+	@Test
+	void testGetVersionParamsSCTModule() {
+		FHIRCodeSystemVersionParams versionParams =
+				FHIRHelper.getCodeSystemVersionParams(null, "http://snomed.info/sct", "http://snomed.info/sct/11000221109", null);
+		assertTrue(versionParams.isSnomed());
+		assertEquals("11000221109", versionParams.getSnomedModule());
+		assertNull(versionParams.getVersion());
+	}
+
+	@Test
+	void testGetVersionParamsSCTModuleAndVersion() {
+		FHIRCodeSystemVersionParams versionParams =
+				FHIRHelper.getCodeSystemVersionParams(null, "http://snomed.info/sct", "http://snomed.info/sct/11000221109/version/20250101", null);
+		assertTrue(versionParams.isSnomed());
+		assertEquals("11000221109", versionParams.getSnomedModule());
+		assertEquals("20250101", versionParams.getVersion());
+	}
+
+	@Test
+	void testGetVersionParamsSCTById() {
+		FHIRCodeSystemVersionParams versionParams =
+				FHIRHelper.getCodeSystemVersionParams("sct_11000221109_20241130", null, null, null);
+		assertTrue(versionParams.isSnomed());
+		assertEquals("11000221109", versionParams.getSnomedModule());
+		assertEquals("20241130", versionParams.getVersion());
+	}
+
+}

--- a/src/test/java/org/snomed/snowstorm/rest/ControllerHelperTest.java
+++ b/src/test/java/org/snomed/snowstorm/rest/ControllerHelperTest.java
@@ -2,12 +2,15 @@ package org.snomed.snowstorm.rest;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.snomed.snowstorm.core.pojo.LanguageDialect;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.List;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
@@ -45,7 +48,7 @@ class ControllerHelperTest {
 	}
 
 	@Test
-	public void getCreatedLocationHeaders_ShouldReturnExpectedLocationFromHttpHeaders_WhenRequestingFromLocalhost() {
+	void getCreatedLocationHeaders_ShouldReturnExpectedLocationFromHttpHeaders_WhenRequestingFromLocalhost() {
 		//given
 		RequestContextHolder.setRequestAttributes(servletRequestAttributes);
 		when(httpServletRequest.getRequestURL()).thenReturn(new StringBuffer().append("http://localhost:8080/imports"));
@@ -58,5 +61,17 @@ class ControllerHelperTest {
 
 		//then
 		assertEquals(expectedLocation, actualLocation);
+	}
+
+	@Test
+	void parseAcceptLanguageHeader_ShouldReturnExpectedLanguage_WhenParsingLanguageWithRegionalDialect() {
+		//given
+		String acceptLanguageHeader = "es-419,es;q=0.9";
+
+		//when
+		final List<LanguageDialect> languageDialects = ControllerHelper.parseAcceptLanguageHeader(acceptLanguageHeader);
+
+		//then
+		assertEquals("es", languageDialects.get(0).getLanguageCode());
 	}
 }


### PR DESCRIPTION
SI Devs - Please wait for Sonja to assign you to this PR. See ISTO-132

Fixes the FHIR CodeSystem lookup operation when the request uses the CodeSystem ID in the URL rather than the system and version parameter.

Issue here #656.

To test this take any id from the CodeSystem listing: /fhir/CodeSystem
For example `sct_11000221109_20241130`, use the id in the lookup operation like this: `/fhir/CodeSystem/sct_11000221109_20241130/$lookup?code=73211009`

The response must include the `name` and `version` of the CodeSystem you selected in the CodeSystem listing. 

