### PR TITLE
Add support for value set.filter operator.equal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.snomed</groupId>
 		<artifactId>snomed-parent-bom</artifactId>
-		<version>3.10.1</version>
+		<version>3.11.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<description>SNOMED CT Terminology Server Using Elasticsearch</description>
 
 	<artifactId>snowstorm</artifactId>
-	<version>10.8.2</version>
+	<version>10.9.0-SNAPSHOT</version>
 	<parent>
 		<groupId>org.snomed</groupId>
 		<artifactId>snomed-parent-bom</artifactId>

--- a/src/main/java/org/snomed/snowstorm/core/data/services/CodeSystemUpgradeService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/CodeSystemUpgradeService.java
@@ -4,6 +4,7 @@ import io.kaicode.elasticvc.api.BranchService;
 import io.kaicode.elasticvc.api.PathUtil;
 import io.kaicode.elasticvc.domain.Branch;
 import io.kaicode.elasticvc.domain.Metadata;
+import org.apache.activemq.command.ActiveMQTopic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.snomed.snowstorm.core.data.domain.CodeSystem;
@@ -14,6 +15,7 @@ import org.snomed.snowstorm.core.data.services.pojo.IntegrityIssueReport;
 import org.snomed.snowstorm.dailybuild.DailyBuildService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jms.core.JmsTemplate;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -24,7 +26,8 @@ import java.util.Map.Entry;
 import java.util.concurrent.ExecutorService;
 
 import static org.snomed.snowstorm.core.data.services.BranchMetadataHelper.INTERNAL_METADATA_KEY;
-import static org.snomed.snowstorm.core.data.services.BranchMetadataKeys.*;
+import static org.snomed.snowstorm.core.data.services.BranchMetadataKeys.DEPENDENCY_PACKAGE;
+import static org.snomed.snowstorm.core.data.services.BranchMetadataKeys.DEPENDENCY_RELEASE;
 
 @Service
 public class CodeSystemUpgradeService {
@@ -58,8 +61,17 @@ public class CodeSystemUpgradeService {
 	@Autowired
 	private ModuleDependencyService moduleDependencyService;
 
+	@Autowired
+	private JmsTemplate jmsTemplate;
+
 	@Value("${snowstorm.rest-api.readonly}")
 	private boolean isReadOnly;
+
+	@Value("${snowstorm.codesystem-version.message.enabled}")
+	private boolean jmsMessageEnabled;
+
+	@Value("${jms.queue.prefix}")
+	private String jmsQueuePrefix;
 
 	private static final Map<String, CodeSystemUpgradeJob> upgradeJobMap = new HashMap<>();
 
@@ -206,6 +218,19 @@ public class CodeSystemUpgradeService {
 			if (job != null) {
 				job.setStatus(CodeSystemUpgradeJob.UpgradeStatus.COMPLETED);
 			}
+
+			if (jmsMessageEnabled) {
+				Map<String, String> payload = new HashMap<>();
+				payload.put("codeSystemShortName", codeSystem.getShortName());
+				payload.put("codeSystemBranchPath", codeSystem.getBranchPath());
+				payload.put(DEPENDENCY_PACKAGE, newParentVersion.getReleasePackage());
+				payload.put(DEPENDENCY_RELEASE, String.valueOf(newParentVersion.getEffectiveDate()));
+
+				String topicDestination = jmsQueuePrefix + ".upgrade.complete";
+				logger.info("Sending JMS Topic - destination {}, payload {}...", topicDestination, payload);
+				jmsTemplate.convertAndSend(new ActiveMQTopic(topicDestination), payload);
+			}
+
 			upgradedSuccessfully = true;
 		} catch (Exception e) {
 			logger.error("Upgrade on {} failed", branchPath, e);

--- a/src/main/java/org/snomed/snowstorm/core/data/services/servicehook/CommitServiceHookClient.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/servicehook/CommitServiceHookClient.java
@@ -125,8 +125,10 @@ public class CommitServiceHookClient implements CommitListener {
 		if (authenticationToken != null) {
 			if (authenticationToken.contains("=")) {
 				return authenticationToken.substring(0, authenticationToken.indexOf("=") + 4) + "...";
-			} else {
+			} else if (authenticationToken.length() > 4) {
 				return authenticationToken.substring(0, 4) + "...";
+			} else {
+				return "WARNING: Authentication Token not present (length = " + authenticationToken.length() + ")";
 			}
 		}
 		return null;

--- a/src/main/java/org/snomed/snowstorm/core/rf2/export/ReferenceSetMemberExportWriter.java
+++ b/src/main/java/org/snomed/snowstorm/core/rf2/export/ReferenceSetMemberExportWriter.java
@@ -34,11 +34,11 @@ class ReferenceSetMemberExportWriter extends ExportWriter<ReferenceSetMember> {
 			for (ReferenceSetMember member : componentBuffer) {
 				bufferedWriter.write(member.getMemberId());
 				bufferedWriter.write(TAB);
-				bufferedWriter.write(member.getEffectiveTimeI() != null ? member.getEffectiveTimeI().toString() : getTransientEffectiveTime());
+				bufferedWriter.write(member.getEffectiveTimeI() == null ? getTransientEffectiveTime() : member.getEffectiveTimeI().toString());
 				bufferedWriter.write(TAB);
 				bufferedWriter.write(member.isActive() ? "1" : "0");
 				bufferedWriter.write(TAB);
-				bufferedWriter.write(member.getModuleId());
+				bufferedWriter.write(member.getModuleId() == null ? "" : member.getModuleId());
 				bufferedWriter.write(TAB);
 				bufferedWriter.write(member.getRefsetId());
 				bufferedWriter.write(TAB);

--- a/src/main/java/org/snomed/snowstorm/fhir/services/FHIRValueSetService.java
+++ b/src/main/java/org/snomed/snowstorm/fhir/services/FHIRValueSetService.java
@@ -918,12 +918,17 @@ public class FHIRValueSetService {
 						throw exception(format("This server does not support ValueSet filter using LOINC property '%s'. " +
 								"Only parent and ancestor filters are supported for LOINC.", property), OperationOutcome.IssueType.NOTSUPPORTED, 400);
 					}
-				} else if (codeSystemVersion.getUrl().startsWith("http://hl7.org/fhir/sid/icd-10")) {
-					// Spec says there are no filters for ICD-9 and 10.
-					throw exception("This server does not expect any ValueSet property filters for ICD-10.", OperationOutcome.IssueType.NOTSUPPORTED, 400);
-				} else {
+				} 
+				// else if (codeSystemVersion.getUrl().startsWith("http://hl7.org/fhir/sid/icd-10")) {
+				// 	// Spec says there are no filters for ICD-9 and 10.
+				// 	throw exception("This server does not expect any ValueSet property filters for ICD-10.", OperationOutcome.IssueType.NOTSUPPORTED, 400);
+				// } 
+				else {
 					// Generic code system
-					if ("concept".equals(property) && op == ValueSet.FilterOperator.ISA) {
+					if ("concept".equals(property) && op == ValueSet.FilterOperator.EQUAL) {
+						Set<String> singleton = Collections.singleton(value);
+						inclusionConstraints.add(new ConceptConstraint(singleton));
+					} else if ("concept".equals(property) && op == ValueSet.FilterOperator.ISA) {
 						Set<String> singleton = Collections.singleton(value);
 						inclusionConstraints.add(new ConceptConstraint(singleton));
 						inclusionConstraints.add(new ConceptConstraint().setAncestor(singleton));

--- a/src/main/java/org/snomed/snowstorm/validation/ConceptDroolsValidationService.java
+++ b/src/main/java/org/snomed/snowstorm/validation/ConceptDroolsValidationService.java
@@ -3,30 +3,38 @@ package org.snomed.snowstorm.validation;
 import com.google.common.collect.Sets;
 import io.kaicode.elasticvc.api.BranchCriteria;
 import io.kaicode.elasticvc.api.ComponentService;
+import io.kaicode.elasticvc.api.VersionControlHelper;
 import org.ihtsdo.drools.domain.Constants;
+import org.ihtsdo.drools.domain.OntologyAxiom;
 import org.ihtsdo.drools.domain.Relationship;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.snomed.otf.owltoolkit.conversion.ConversionException;
 import org.snomed.snowstorm.config.Config;
-import org.snomed.snowstorm.core.data.domain.Concept;
-import org.snomed.snowstorm.core.data.domain.Concepts;
-import org.snomed.snowstorm.core.data.domain.ReferenceSetMember;
-import org.snomed.snowstorm.core.data.domain.SnomedComponent;
+import org.snomed.snowstorm.core.data.domain.*;
+import org.snomed.snowstorm.core.data.services.AxiomConversionService;
+import org.snomed.snowstorm.core.data.services.pojo.SAxiomRepresentation;
 import org.snomed.snowstorm.validation.domain.DroolsConcept;
-import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
-import org.springframework.data.elasticsearch.core.SearchHit;
+import org.snomed.snowstorm.validation.domain.DroolsOntologyAxiom;
+import org.snomed.snowstorm.validation.domain.DroolsRelationship;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHitsIterator;
-import org.springframework.util.CollectionUtils;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
 import static co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.bool;
 import static io.kaicode.elasticvc.helper.QueryHelper.termQuery;
-import static io.kaicode.elasticvc.helper.QueryHelper.termsQuery;
 
 public class ConceptDroolsValidationService implements org.ihtsdo.drools.service.ConceptService {
 
+	private final Logger logger = LoggerFactory.getLogger(getClass());
+
+	private final VersionControlHelper versionControlHelper;
+	private final AxiomConversionService axiomConversionService;
 	private final BranchCriteria branchCriteria;
 	private final ElasticsearchOperations elasticsearchOperations;
 	private final DisposableQueryService queryService;
@@ -34,7 +42,9 @@ public class ConceptDroolsValidationService implements org.ihtsdo.drools.service
 	private final Map<String, Boolean> conceptActiveStates = Collections.synchronizedMap(new HashMap<>());
 	private final Map<String, DroolsConcept> concepts = Collections.synchronizedMap(new HashMap<>());
 
-	ConceptDroolsValidationService(BranchCriteria branchCriteria, ElasticsearchOperations elasticsearchOperations, DisposableQueryService queryService, Set<String> inferredTopLevelHierarchies) {
+	ConceptDroolsValidationService(BranchCriteria branchCriteria, ElasticsearchOperations elasticsearchOperations, DisposableQueryService queryService, Set<String> inferredTopLevelHierarchies, VersionControlHelper versionControlHelper, AxiomConversionService axiomConversionService) {
+		this.versionControlHelper = versionControlHelper;
+		this.axiomConversionService = axiomConversionService;
 		this.branchCriteria = branchCriteria;
 		this.elasticsearchOperations = elasticsearchOperations;
 		this.queryService = queryService;
@@ -81,6 +91,118 @@ public class ConceptDroolsValidationService implements org.ihtsdo.drools.service
 		}
 		return false;
 	}
+
+	@Override
+	public boolean isConceptModellingChanged(org.ihtsdo.drools.domain.Concept concept) {
+		BranchCriteria branchCriteriaAtBranchCreation = versionControlHelper.getBranchCriteriaAtBranchCreationTimepoint(this.branchCriteria.getBranchPath());
+		if (hasChangedAdditionalAxioms(concept, branchCriteriaAtBranchCreation)) {
+			return true;
+		} else {
+			return hasChangedInferredRelationships(concept, branchCriteriaAtBranchCreation);
+		}
+	}
+
+	private boolean hasChangedInferredRelationships(org.ihtsdo.drools.domain.Concept concept, BranchCriteria branchCriteriaAtBranchCreation) {
+		// Find inferred relationships
+		NativeQuery query = new NativeQueryBuilder()
+			.withQuery(bool(b -> b
+					.must(branchCriteriaAtBranchCreation.getEntityBranchCriteria(org.snomed.snowstorm.core.data.domain.Relationship.class))
+					.must(termQuery(org.snomed.snowstorm.core.data.domain.Relationship.Fields.SOURCE_ID, concept.getId()))
+					.must(termQuery(org.snomed.snowstorm.core.data.domain.Relationship.Fields.CHARACTERISTIC_TYPE_ID, org.snomed.snowstorm.core.data.domain.Relationship.CharacteristicType.inferred.getConceptId()))
+			))
+			.withPageable(Config.PAGE_OF_ONE)
+			.build();
+		List<org.snomed.snowstorm.core.data.domain.Relationship> relationshipsAtBranchCreation = elasticsearchOperations.search(query, org.snomed.snowstorm.core.data.domain.Relationship.class).stream().map(SearchHit::getContent).toList();
+		List<DroolsRelationship> droolsRelationships = (List<DroolsRelationship>) concept.getRelationships().stream().filter(r -> r.getAxiomId() == null).toList();
+
+		if (droolsRelationships.size() != relationshipsAtBranchCreation.size()) return true;
+		for (DroolsRelationship droolsRelationship : droolsRelationships) {
+			boolean foundRelationship = false;
+			for (org.snomed.snowstorm.core.data.domain.Relationship relationship : relationshipsAtBranchCreation) {
+				if (droolsRelationship.getId().equals(relationship.getId())
+					&& droolsRelationship.getTypeId().equals(relationship.getTypeId())
+					&& ((droolsRelationship.getDestinationId() != null &&droolsRelationship.getDestinationId().equals(relationship.getDestinationId()))
+					|| (droolsRelationship.getConcreteValue() != null && droolsRelationship.getConcreteValue().equals(relationship.getConcreteValue() != null ? relationship.getConcreteValue().getValue() : null)))
+					&& droolsRelationship.isActive() == relationship.isActive()
+					&& droolsRelationship.getRelationshipGroup() == relationship.getRelationshipGroup()) {
+					foundRelationship = true;
+				}
+			}
+			if (!foundRelationship) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private boolean hasChangedAdditionalAxioms(org.ihtsdo.drools.domain.Concept concept, BranchCriteria branchCriteriaAtBranchCreation) {
+		// Find axiom members
+		List<Axiom> additionalAxiomsAtBranchCreation = new ArrayList<>();
+		NativeQuery query = new NativeQueryBuilder()
+				.withQuery(bool(bq -> bq
+						.must(branchCriteriaAtBranchCreation.getEntityBranchCriteria(ReferenceSetMember.class))
+						.must(termQuery(ReferenceSetMember.Fields.REFSET_ID, Concepts.OWL_AXIOM_REFERENCE_SET))
+						.must(termQuery(ReferenceSetMember.Fields.REFERENCED_COMPONENT_ID, concept.getId()))))
+				.withPageable(ComponentService.LARGE_PAGE)
+				.build();
+		try (final SearchHitsIterator <ReferenceSetMember> members = elasticsearchOperations.searchForStream(query, ReferenceSetMember.class)) {
+			members.forEachRemaining(hit -> {
+				ReferenceSetMember member = hit.getContent();
+				try {
+					SAxiomRepresentation axiomRepresentation = axiomConversionService.convertAxiomMemberToAxiomRepresentation(member);
+					if (axiomRepresentation != null && (axiomRepresentation.getLeftHandSideNamedConcept() != null)) {
+						// Regular Axiom
+						Set<org.snomed.snowstorm.core.data.domain.Relationship> relationships = axiomRepresentation.getRightHandSideRelationships();
+						additionalAxiomsAtBranchCreation.add(new Axiom(member, axiomRepresentation.isPrimitive() ? Concepts.PRIMITIVE : Concepts.FULLY_DEFINED, relationships));
+					}
+				} catch (ConversionException e) {
+					logger.error("Failed to deserialize axiom {}", member.getId(), e);
+				}
+			});
+		}
+		// verify if there is any changes in additional Axiom
+		List<DroolsOntologyAxiom> additionalAxioms = new ArrayList<>();
+		for (OntologyAxiom ontologyAxiom : concept.getOntologyAxioms()) {
+			DroolsOntologyAxiom droolsOntologyAxiom = (DroolsOntologyAxiom) ontologyAxiom;
+			if (!droolsOntologyAxiom.isAxiomGCI()) {
+				additionalAxioms.add(droolsOntologyAxiom);
+			}
+		}
+		if (additionalAxiomsAtBranchCreation.size() != additionalAxioms.size()) return true;
+		for (DroolsOntologyAxiom droolsOntologyAxiom : additionalAxioms) {
+			if (isAdditionalAxiomChanged(concept, droolsOntologyAxiom, additionalAxiomsAtBranchCreation)) return true;
+		}
+		return false;
+	}
+
+	private boolean isAdditionalAxiomChanged(org.ihtsdo.drools.domain.Concept concept, DroolsOntologyAxiom droolsOntologyAxiom, List<Axiom> additionalAxiomsAtBranchCreation) {
+		boolean foundAxiom = false;
+		for (Axiom axiom : additionalAxiomsAtBranchCreation) {
+			if (droolsOntologyAxiom.getId().equals(axiom.getAxiomId()) && droolsOntologyAxiom.isActive() == axiom.isActive()) {
+				foundAxiom = true;
+				List<DroolsRelationship> droolsRelationships = (List<DroolsRelationship>) concept.getRelationships().stream().filter(r -> droolsOntologyAxiom.getId().equals(r.getAxiomId())).toList();
+				if (droolsRelationships.size() != axiom.getRelationships().size()) return true;
+				for (DroolsRelationship droolsRelationship : droolsRelationships) {
+					if (isRelationshipChanged(axiom, droolsRelationship)) return true;
+				}
+			}
+		}
+        return !foundAxiom;
+    }
+
+	private boolean isRelationshipChanged(Axiom axiom, DroolsRelationship droolsRelationship) {
+		boolean foundRelationship = false;
+		for (org.snomed.snowstorm.core.data.domain.Relationship relationship : axiom.getRelationships()) {
+			if (droolsRelationship.getTypeId().equals(relationship.getTypeId())
+				&& ((droolsRelationship.getDestinationId() != null && droolsRelationship.getDestinationId().equals(relationship.getDestinationId()))
+					|| (droolsRelationship.getConcreteValue() != null && droolsRelationship.getConcreteValue().equals(relationship.getConcreteValue() != null ? relationship.getConcreteValue().getValue() : null)))
+				&& droolsRelationship.isActive() == relationship.isActive()
+				&& droolsRelationship.getRelationshipGroup() == relationship.getRelationshipGroup()) {
+				foundRelationship = true;
+			}
+		}
+        return !foundRelationship;
+    }
 
 	@Override
 	public org.ihtsdo.drools.domain.Concept findById(String conceptId) {

--- a/src/main/java/org/snomed/snowstorm/validation/DroolsValidationService.java
+++ b/src/main/java/org/snomed/snowstorm/validation/DroolsValidationService.java
@@ -65,6 +65,9 @@ public class DroolsValidationService {
 	@Autowired
 	private ConceptService conceptService;
 
+	@Autowired
+	private AxiomConversionService axiomConversionService;
+
 	private final String droolsRulesPath;
 	private final ResourceManager testResourceManager;
 
@@ -122,7 +125,7 @@ public class DroolsValidationService {
 		setReleaseHashAndEffectiveTime(concepts, branchCriteria);
 		Set<String> inferredTopLevelHierarchies = getTopLevelHierarchies();
 		DisposableQueryService disposableQueryService = new DisposableQueryService(queryService, branchPath, branchCriteria);
-		ConceptDroolsValidationService droolsConceptService = new ConceptDroolsValidationService(branchCriteria, elasticsearchOperations, disposableQueryService, inferredTopLevelHierarchies);
+		ConceptDroolsValidationService droolsConceptService = new ConceptDroolsValidationService(branchCriteria, elasticsearchOperations, disposableQueryService, inferredTopLevelHierarchies, versionControlHelper, axiomConversionService);
 		DescriptionDroolsValidationService droolsDescriptionService = new DescriptionDroolsValidationService(branchPath, branchCriteria, elasticsearchOperations,
 				this.descriptionService, disposableQueryService, testResourceProvider, inferredTopLevelHierarchies);
 		RelationshipDroolsValidationService relationshipService = new RelationshipDroolsValidationService(disposableQueryService);

--- a/src/main/java/org/snomed/snowstorm/validation/domain/DroolsConcept.java
+++ b/src/main/java/org/snomed/snowstorm/validation/domain/DroolsConcept.java
@@ -45,7 +45,7 @@ public class DroolsConcept implements org.ihtsdo.drools.domain.Concept {
 					r.setModuleId(axiom.getModuleId());
 					relationships.add(new DroolsRelationship(axiom.getAxiomId(), false, r));
 				});
-				ontologyAxioms.add(new DroolsOntologyAxiom(axiom.getId(), axiom.isActive(), Concepts.definitionStatusNames.get(Concepts.PRIMITIVE).equals(axiom.getDefinitionStatus()), conceptId, axiom.getModuleId()));
+				ontologyAxioms.add(new DroolsOntologyAxiom(axiom.getId(), axiom.getEffectiveTimeI(), axiom.isActive(), Concepts.definitionStatusNames.get(Concepts.PRIMITIVE).equals(axiom.getDefinitionStatus()), conceptId, axiom.getModuleId(), false));
 			});
 		}
 		if (concept.getGciAxioms() != null) {
@@ -55,7 +55,7 @@ public class DroolsConcept implements org.ihtsdo.drools.domain.Concept {
 					r.setActive(axiom.isActive());
 					relationships.add(new DroolsRelationship(axiom.getAxiomId(), true, r));
 				});
-				ontologyAxioms.add(new DroolsOntologyAxiom(axiom.getId(), axiom.isActive(), Concepts.definitionStatusNames.get(Concepts.PRIMITIVE).equals(axiom.getDefinitionStatus()), conceptId, axiom.getModuleId()));
+				ontologyAxioms.add(new DroolsOntologyAxiom(axiom.getId(), axiom.getEffectiveTimeI(), axiom.isActive(), Concepts.definitionStatusNames.get(Concepts.PRIMITIVE).equals(axiom.getDefinitionStatus()), conceptId, axiom.getModuleId(), true));
 			});
 		}
 	}
@@ -108,5 +108,10 @@ public class DroolsConcept implements org.ihtsdo.drools.domain.Concept {
 	@Override
 	public String getModuleId() {
 		return concept.getModuleId();
+	}
+
+	@Override
+	public String getEffectiveTime() {
+		return concept.getEffectiveTime();
 	}
 }

--- a/src/main/java/org/snomed/snowstorm/validation/domain/DroolsDescription.java
+++ b/src/main/java/org/snomed/snowstorm/validation/domain/DroolsDescription.java
@@ -88,4 +88,9 @@ public class DroolsDescription implements Description {
 	public String getModuleId() {
 		return description.getModuleId();
 	}
+
+	@Override
+	public String getEffectiveTime() {
+		return description.getEffectiveTime();
+	}
 }

--- a/src/main/java/org/snomed/snowstorm/validation/domain/DroolsOntologyAxiom.java
+++ b/src/main/java/org/snomed/snowstorm/validation/domain/DroolsOntologyAxiom.java
@@ -7,21 +7,25 @@ import java.util.Collection;
 public class DroolsOntologyAxiom implements OntologyAxiom {
 
 	private String id;
+	private String effectiveTime;
 	private boolean active;
 	private boolean published;
 	private boolean primitive;
 	private boolean released;
+	private boolean axiomGci;
 	private String moduleId;
 	private Collection<String> ownExpressionNamedConcepts;
 	private String owlExpression;
 	private String referencedComponentId;
 
-	public DroolsOntologyAxiom(String id, boolean active, boolean primitive, String referencedComponentId, String moduleId) {
+	public DroolsOntologyAxiom(String id, Integer effectiveTimeI, boolean active, boolean primitive, String referencedComponentId, String moduleId, boolean axiomGci) {
 		this.id = id;
+		this.effectiveTime = effectiveTimeI != null ? effectiveTimeI.toString() : null;
 		this.active = active;
 		this.primitive = primitive;
 		this.referencedComponentId = referencedComponentId;
 		this.moduleId = moduleId;
+		this.axiomGci = axiomGci;
 	}
 
 	@Override
@@ -37,6 +41,11 @@ public class DroolsOntologyAxiom implements OntologyAxiom {
 	@Override
 	public Collection<String> getOwlExpressionNamedConcepts() {
 		return ownExpressionNamedConcepts;
+	}
+
+	@Override
+	public boolean isAxiomGCI() {
+		return axiomGci;
 	}
 
 	@Override
@@ -68,4 +77,10 @@ public class DroolsOntologyAxiom implements OntologyAxiom {
 	public String getModuleId() {
 		return moduleId;
 	}
+
+	@Override
+	public String getEffectiveTime() {
+		return effectiveTime;
+	}
+
 }

--- a/src/main/java/org/snomed/snowstorm/validation/domain/DroolsRelationship.java
+++ b/src/main/java/org/snomed/snowstorm/validation/domain/DroolsRelationship.java
@@ -89,4 +89,9 @@ public class DroolsRelationship implements org.ihtsdo.drools.domain.Relationship
 	public String getModuleId() {
 		return relationship.getModuleId();
 	}
+
+	@Override
+	public String getEffectiveTime() {
+		return relationship.getEffectiveTime();
+	}
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -239,9 +239,11 @@ codesystem.config.SNOMEDCT-UK=United Kingdom Edition|83821000000107|gb|NHS Digit
 codesystem.config.SNOMEDCT-UKC=United Kingdom Clinical Edition|999000021000000109|gb|NHS Digital Information Representation Services
 codesystem.config.SNOMEDCT-US=United States Edition|731000124108|us|National Library of Medicine
 codesystem.config.SNOMEDCT-UY=Uruguay Edition|5631000179106|uy|Centro de Servicios de Salud - NRC
+
 codesystem.config.SNOMEDCT-ICD10=ICD10|5991000124107
-
-
+codesystem.config.SNOMEDCT-LOINCEXT=LOINC Ontology|11010000107|us|Regenstrief Institute
+codesystem.config.SNOMEDCT-NUVA=NUVA Extension|11002000107|us|Syadem
+codesystem.config.SNOMEDCT-NPU=NPU Extension|11003000102|gb|IFCC and IUPAC
 # ----------------------------------------
 # SNOMED Known Dialects - Individual Configuration
 #   Configuration information for known dialects with a Language Reference Set

--- a/src/test/java/org/snomed/snowstorm/validation/ConceptDroolsValidationServiceTest.java
+++ b/src/test/java/org/snomed/snowstorm/validation/ConceptDroolsValidationServiceTest.java
@@ -10,6 +10,7 @@ import org.snomed.snowstorm.AbstractTest;
 import org.snomed.snowstorm.TestConfig;
 import org.snomed.snowstorm.core.data.domain.Concept;
 import org.snomed.snowstorm.core.data.domain.Concepts;
+import org.snomed.snowstorm.core.data.services.AxiomConversionService;
 import org.snomed.snowstorm.core.data.services.ConceptService;
 import org.snomed.snowstorm.core.data.services.QueryService;
 import org.snomed.snowstorm.core.data.services.ServiceException;
@@ -36,6 +37,9 @@ class ConceptDroolsValidationServiceTest extends AbstractTest {
 	@Autowired
 	private QueryService queryService;
 
+	@Autowired
+	private AxiomConversionService axiomConversionService;
+
 	private ConceptDroolsValidationService validationService;
 
 	@BeforeEach
@@ -46,7 +50,7 @@ class ConceptDroolsValidationServiceTest extends AbstractTest {
 
 		BranchCriteria branchCriteria = versionControlHelper.getBranchCriteria(branch);
 		DisposableQueryService disposableQueryService = new DisposableQueryService(queryService, branch, branchCriteria);
-		validationService = new ConceptDroolsValidationService(branchCriteria, elasticsearchOperations, disposableQueryService, Collections.emptySet());
+		validationService = new ConceptDroolsValidationService(branchCriteria, elasticsearchOperations, disposableQueryService, Collections.emptySet(), versionControlHelper, axiomConversionService);
 	}
 
 	@Test


### PR DESCRIPTION
This pull request makes changes to the `collectConstraints` method in the `FHIRValueSetService` class to update how filters are handled for generic code systems and ICD-10. The most notable changes include commenting out the block that explicitly disallowed property filters for ICD-10 and introducing support for the `EQUAL` filter operator for generic code systems.

Updates to filter handling:

* [`src/main/java/org/snomed/snowstorm/fhir/services/FHIRValueSetService.java`](diffhunk://#diff-8c9ac58f304df98f4e50fe9b68a87381a198864d758198049a7485ae0cc1174aL921-R931): Commented out the block that disallowed property filters for ICD-10, making the code more flexible for future updates or extensions.
* [`src/main/java/org/snomed/snowstorm/fhir/services/FHIRValueSetService.java`](diffhunk://#diff-8c9ac58f304df98f4e50fe9b68a87381a198864d758198049a7485ae0cc1174aL921-R931): Added support for the `EQUAL` filter operator for generic code systems, enabling inclusion constraints to handle equality comparisons.