### PR TITLE
ISTO-143 Fix ECL ancestor 10K limit.

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/services/QueryService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/QueryService.java
@@ -402,13 +402,14 @@ public class QueryService implements ApplicationContextAware {
 				)
 				.withPageable(LARGE_PAGE)
 				.build();
-		final List<QueryConcept> concepts = elasticsearchOperations.search(searchQuery, QueryConcept.class)
-				.stream().map(SearchHit::getContent).toList();
-		Set<Long> allAncestors = new HashSet<>();
-		for (QueryConcept concept : concepts) {
-			allAncestors.addAll(concept.getAncestors());
+		try (SearchHitsIterator<QueryConcept> stream = elasticsearchOperations.searchForStream(searchQuery, QueryConcept.class)) {
+			final List<QueryConcept> concepts = stream.stream().map(SearchHit::getContent).toList();
+			Set<Long> allAncestors = new HashSet<>();
+			for (QueryConcept concept : concepts) {
+				allAncestors.addAll(concept.getAncestors());
+			}
+			return allAncestors;
 		}
-		return allAncestors;
 	}
 
 	public Set<Long> findParentIdsAsUnion(BranchCriteria branchCriteria, boolean stated, Collection<Long> conceptId) {


### PR DESCRIPTION
This is an ECL fix for queries like "(>(^331101000221109.774160008))" where the subquery returns more than 10 thousand results.

See https://jira.ihtsdotools.org/browse/ISTO-143