### PR TITLE
BROWSE-673 Fix browser search refset filter

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/services/DescriptionService.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/services/DescriptionService.java
@@ -66,6 +66,7 @@ import static io.kaicode.elasticvc.helper.QueryHelper.*;
 import static org.snomed.snowstorm.config.Config.*;
 import static org.snomed.snowstorm.core.data.domain.ReferenceSetMember.Fields.REFSET_ID;
 import static org.snomed.snowstorm.core.data.domain.ReferenceSetMember.LanguageFields.ACCEPTABILITY_ID_FIELD_PATH;
+import static org.snomed.snowstorm.core.data.domain.SnomedComponent.Fields.ACTIVE;
 import static org.snomed.snowstorm.core.util.AggregationUtils.getAggregations;
 
 
@@ -810,6 +811,7 @@ public class DescriptionService extends ComponentService {
 						new NativeQueryBuilder()
 								.withQuery(bool(bq -> bq
 										.must(termQuery(REFSET_ID, criteria.getConceptRefset()))
+										.must(termQuery(ACTIVE, true))
 										.filter(branchCriteria.getEntityBranchCriteria(ReferenceSetMember.class))
 										.filter(termsQuery(ReferenceSetMember.Fields.REFERENCED_COMPONENT_ID, conceptIdsToSearch)))
 								)


### PR DESCRIPTION
Without this fix the browser description search refset filter does not work. When a filter is applied the matched concepts have to have a member in the refset but the member may be inactive. When a refset member is inactive the concept must not be considered as a member of that refset!