### PR TITLE
SIMPLEX-201 Fast language-only RF2 export.

### DIFF
--- a/src/main/java/org/snomed/snowstorm/core/data/domain/jobs/ExportConfiguration.java
+++ b/src/main/java/org/snomed/snowstorm/core/data/domain/jobs/ExportConfiguration.java
@@ -34,6 +34,9 @@ public class ExportConfiguration {
 	private boolean conceptsAndRelationshipsOnly;
 
 	@Schema(defaultValue = "false")
+	private boolean languageOnly;
+
+	@Schema(defaultValue = "false")
 	private boolean unpromotedChangesOnly;
 
 	@Schema(defaultValue = "false")
@@ -100,6 +103,14 @@ public class ExportConfiguration {
 
 	public void setConceptsAndRelationshipsOnly(boolean conceptsAndRelationshipsOnly) {
 		this.conceptsAndRelationshipsOnly = conceptsAndRelationshipsOnly;
+	}
+
+	public boolean isLanguageOnly() {
+		return languageOnly;
+	}
+
+	public void setLanguageOnly(boolean languageOnly) {
+		this.languageOnly = languageOnly;
 	}
 
 	public boolean isUnpromotedChangesOnly() {

--- a/src/main/java/org/snomed/snowstorm/core/rf2/export/ExportService.java
+++ b/src/main/java/org/snomed/snowstorm/core/rf2/export/ExportService.java
@@ -8,9 +8,7 @@ import com.google.common.collect.Sets;
 import io.kaicode.elasticvc.api.BranchCriteria;
 import io.kaicode.elasticvc.api.BranchService;
 import io.kaicode.elasticvc.api.VersionControlHelper;
-
 import org.apache.tomcat.util.http.fileupload.util.Streams;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.snomed.snowstorm.core.data.domain.*;
@@ -21,11 +19,11 @@ import org.snomed.snowstorm.core.data.services.*;
 import org.snomed.snowstorm.core.rf2.RF2Type;
 import org.snomed.snowstorm.core.util.DateUtil;
 import org.snomed.snowstorm.core.util.TimerUtil;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHitsIterator;
-import org.springframework.data.elasticsearch.client.elc.NativeQuery;
-import org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
@@ -37,10 +35,11 @@ import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import static co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.bool;
 import static io.kaicode.elasticvc.api.ComponentService.LARGE_PAGE;
-import static java.lang.String.format;
-import static co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.*;
 import static io.kaicode.elasticvc.helper.QueryHelper.*;
+import static java.lang.String.format;
+import static org.snomed.snowstorm.core.data.domain.Concepts.LANG_REFSET;
 
 @Service
 public class ExportService {
@@ -90,7 +89,7 @@ public class ExportService {
 
 	public ExportConfiguration getExportJobOrThrow(String exportId) {
 		Optional<ExportConfiguration> config = exportConfigurationRepository.findById(exportId);
-		if (!config.isPresent()) {
+		if (config.isEmpty()) {
 			throw new NotFoundException("Export job not found.");
 		}
 		return config.get();
@@ -107,28 +106,31 @@ public class ExportService {
 		}
 
 		File exportFile = exportRF2ArchiveFile(exportConfiguration.getBranchPath(), exportConfiguration.getFilenameEffectiveDate(),
-				exportConfiguration.getType(), exportConfiguration.isConceptsAndRelationshipsOnly(), exportConfiguration.isUnpromotedChangesOnly(),
+				exportConfiguration.getType(), exportConfiguration.isConceptsAndRelationshipsOnly(), exportConfiguration.isLanguageOnly(), exportConfiguration.isUnpromotedChangesOnly(),
 				exportConfiguration.getTransientEffectiveTime(), exportConfiguration.getStartEffectiveTime(), exportConfiguration.getModuleIds(),
 				exportConfiguration.isLegacyZipNaming(), exportConfiguration.getRefsetIds(), exportConfiguration.getId());
-		logger.info("Transmitting " + exportConfiguration.getId() + " export file " + exportFile);
+
+		logger.debug("Transmitting {} export file {}", exportConfiguration.getId(), exportFile);
 		try (FileInputStream inputStream = new FileInputStream(exportFile)) {
 			long fileSize = Files.size(exportFile.toPath());
 			long bytesTransferred = Streams.copy(inputStream, outputStream, false);
 			exportConfiguration.setStatus(ExportStatus.COMPLETED);
 			exportConfigurationRepository.save(exportConfiguration);
-			logger.info("Transmitted " + bytesTransferred + "bytes (file size = " + fileSize + "bytes) for export " + exportConfiguration.getId());
+			logger.debug("Transmitted {}bytes (file size = {}bytes) for export {}", bytesTransferred, fileSize, exportConfiguration.getId());
 		} catch (IOException e) {
 			exportConfiguration.setStatus(ExportStatus.FAILED);
 			exportConfigurationRepository.save(exportConfiguration);
 			throw new ExportException("Failed to copy RF2 data into output stream.", e);
 		} finally {
-			exportFile.delete();
-			logger.info("Deleted " + exportConfiguration.getId() + " export file " + exportFile);
+			if (!exportFile.delete()) {
+				logger.warn("Failed to delete temporary file {}", exportFile.getAbsolutePath());
+			}
+			logger.debug("Deleted {} export file {}", exportConfiguration.getId(), exportFile);
 		}
 	}
 
 	public File exportRF2ArchiveFile(String branchPath, String filenameEffectiveDate, RF2Type exportType, boolean forClassification) throws ExportException {
-		return exportRF2ArchiveFile(branchPath, filenameEffectiveDate, exportType, forClassification, false, null, null, new HashSet<>(), true, new HashSet<>(), null);
+		return exportRF2ArchiveFile(branchPath, filenameEffectiveDate, exportType, forClassification, false, false, null, null, new HashSet<>(), true, new HashSet<>(), null);
 	}
 
 	public void exportRF2ArchiveAsync(ExportConfiguration exportConfiguration) {
@@ -146,7 +148,8 @@ public class ExportService {
 			File file = null;
 			try {
 				file = exportRF2ArchiveFile(exportConfiguration.getBranchPath(), exportConfiguration.getFilenameEffectiveDate(),
-						exportConfiguration.getType(), exportConfiguration.isConceptsAndRelationshipsOnly(), exportConfiguration.isUnpromotedChangesOnly(),
+						exportConfiguration.getType(), exportConfiguration.isConceptsAndRelationshipsOnly(), exportConfiguration.isLanguageOnly(),
+						exportConfiguration.isUnpromotedChangesOnly(),
 						exportConfiguration.getTransientEffectiveTime(), exportConfiguration.getStartEffectiveTime(), exportConfiguration.getModuleIds(),
 						exportConfiguration.isLegacyZipNaming(), exportConfiguration.getRefsetIds(), exportConfiguration.getId());
 
@@ -190,7 +193,7 @@ public class ExportService {
 	}
 
 	private File exportRF2ArchiveFile(String branchPath, String filenameEffectiveDate, RF2Type exportType, boolean forClassification,
-			boolean unpromotedChangesOnly, String transientEffectiveTime, String startEffectiveTime, Set<String> moduleIds,
+			boolean languageOnly, boolean unpromotedChangesOnly, String transientEffectiveTime, String startEffectiveTime, Set<String> moduleIds,
 			boolean legacyZipNaming, Set<String> refsetIds, String exportId) throws ExportException {
 
 		if (exportType == RF2Type.FULL) {
@@ -245,83 +248,18 @@ public class ExportService {
 						logger.info("{} text defintion states exported", textDefinitionLines);
 					}
 
-					// Write Stated Relationships
-					Query relationshipBranchCritera = selectionBranchCriteria.getEntityBranchCriteria(Relationship.class);
-					BoolQuery.Builder relationshipQuery = getContentQuery(exportType, moduleIds, startEffectiveTime, relationshipBranchCritera);
-					relationshipQuery.must(termQuery(Relationship.Fields.CHARACTERISTIC_TYPE_ID, Concepts.STATED_RELATIONSHIP));
-					int statedRelationshipLines = exportComponents(Relationship.class, entryDirectoryPrefix, "Terminology/", "sct2_StatedRelationship_", filenameEffectiveDate, exportType, zipOutputStream,
-							relationshipQuery.build()._toQuery(), transientEffectiveTime, null, codeSystemRF2Name, null);
-					logger.info("{} stated relationship states exported", statedRelationshipLines);
-
-					// Write Inferred non-concrete Relationships
-					relationshipQuery = getContentQuery(exportType, moduleIds, startEffectiveTime, relationshipBranchCritera);
-					// Not 'stated' will include inferred and additional
-					relationshipQuery.mustNot(termQuery(Relationship.Fields.CHARACTERISTIC_TYPE_ID, Concepts.STATED_RELATIONSHIP));
-					relationshipQuery.must(existsQuery(Relationship.Fields.DESTINATION_ID));
-					int inferredRelationshipLines = exportComponents(Relationship.class, entryDirectoryPrefix, "Terminology/", "sct2_Relationship_", filenameEffectiveDate, exportType, zipOutputStream,
-							relationshipQuery.build()._toQuery(), transientEffectiveTime, null, codeSystemRF2Name, null);
-					logger.info("{} inferred (non-concrete) and additional relationship states exported", inferredRelationshipLines);
-
-					// Write Concrete Inferred Relationships
-					relationshipQuery = getContentQuery(exportType, moduleIds, startEffectiveTime, relationshipBranchCritera);
-					relationshipQuery.must(termQuery(Relationship.Fields.CHARACTERISTIC_TYPE_ID, Concepts.INFERRED_RELATIONSHIP));
-					relationshipQuery.must(existsQuery(Relationship.Fields.VALUE));
-					int inferredConcreteRelationshipLines = exportComponents(Relationship.class, entryDirectoryPrefix, "Terminology/", "sct2_RelationshipConcreteValues_", filenameEffectiveDate, exportType,
-							zipOutputStream,
-							relationshipQuery.build()._toQuery(), transientEffectiveTime, null, codeSystemRF2Name, null);
-					logger.info("{} concrete inferred relationship states exported", inferredConcreteRelationshipLines);
-
-					// Write Identifiers
-					BoolQuery.Builder identifierContentQuery = getContentQuery(exportType, moduleIds, startEffectiveTime, selectionBranchCriteria.getEntityBranchCriteria(Identifier.class));
-					int identifierLines = exportComponents(Identifier.class, entryDirectoryPrefix, "Terminology/", "sct2_Identifier_", filenameEffectiveDate, exportType, zipOutputStream,
-							identifierContentQuery.build()._toQuery(), transientEffectiveTime, null, codeSystemRF2Name, null);
-					logger.info("{} identifier states exported", identifierLines);
+					if (!languageOnly) {
+						exportRelationshipsAllTypes(filenameEffectiveDate, exportType, transientEffectiveTime, startEffectiveTime, moduleIds,
+								selectionBranchCriteria, entryDirectoryPrefix, zipOutputStream, codeSystemRF2Name);
+						// Write Identifiers
+						exportIdentifiers(filenameEffectiveDate, exportType, transientEffectiveTime, startEffectiveTime, moduleIds,
+								selectionBranchCriteria, entryDirectoryPrefix, zipOutputStream, codeSystemRF2Name);
+					}
 				}
 
 				// Write Reference Sets
-				List<ReferenceSetType> referenceSetTypes = getReferenceSetTypes(allContentBranchCriteria.getEntityBranchCriteria(ReferenceSetType.class)).stream()
-						.filter(type -> !forClassification || refsetTypesRequiredForClassification.contains(type.getConceptId()))
-						.collect(Collectors.toList());
-
-				logger.info("{} Reference Set Types found for this export: {}", referenceSetTypes.size(), referenceSetTypes);
-
-				Query memberBranchCriteria = selectionBranchCriteria.getEntityBranchCriteria(ReferenceSetMember.class);
-				Set<String> moduleIdsBackup = moduleIds;
-				for (ReferenceSetType referenceSetType : referenceSetTypes) {
-					List<Long> refsetsOfThisType = new ArrayList<>(queryService.findDescendantIdsAsUnion(allContentBranchCriteria, true, Collections.singleton(Long.parseLong(referenceSetType.getConceptId()))));
-					refsetsOfThisType.add(Long.parseLong(referenceSetType.getConceptId()));
-					for (Long refsetToExport : refsetsOfThisType) {
-						if (!refsetOnlyExport || refsetIds.contains(refsetToExport.toString())) {
-							if (Concepts.MODULE_DEPENDENCY_REFERENCE_SET.equals(String.valueOf(refsetToExport))) {
-								moduleIds.addAll(sBranchService.getModules(branchPath));
-							}
-
-							BoolQuery.Builder memberQueryBuilder = getContentQuery(exportType, moduleIds, startEffectiveTime, memberBranchCriteria);
-							memberQueryBuilder.must(termQuery(ReferenceSetMember.Fields.REFSET_ID, refsetToExport));
-							Query memberQuery = memberQueryBuilder.build()._toQuery();
-							long memberCount = elasticsearchOperations.count(getNativeSearchQuery(memberQuery), ReferenceSetMember.class);
-							if (memberCount > 0) {
-								logger.info("Exporting Reference Set {} {} with {} members", refsetToExport, referenceSetType.getName(), memberCount);
-								String exportDir = referenceSetType.getExportDir();
-								String entryDirectory = !exportDir.startsWith("/") ? "Refset/" + exportDir + "/" : exportDir.substring(1) + "/";
-								String entryFilenamePrefix = (!entryDirectory.startsWith("Terminology/") ? "der2_" : "sct2_") + referenceSetType.getFieldTypes() + "Refset_" + referenceSetType.getName() + (refsetsOfThisType.size() > 1 ? refsetToExport : "");
-								exportComponents(
-										ReferenceSetMember.class,
-										entryDirectoryPrefix, entryDirectory,
-										entryFilenamePrefix,
-										filenameEffectiveDate,
-										exportType,
-										zipOutputStream,
-										memberQuery,
-										transientEffectiveTime,
-										referenceSetType.getFieldNameList(),
-										codeSystemRF2Name,
-										null);
-							}
-							moduleIds = moduleIdsBackup;
-						}
-					}
-				}
+				exportRefsetMembers(branchPath, filenameEffectiveDate, exportType, forClassification, languageOnly, transientEffectiveTime, startEffectiveTime,
+						moduleIds, refsetIds, allContentBranchCriteria, selectionBranchCriteria, refsetOnlyExport, entryDirectoryPrefix, zipOutputStream, codeSystemRF2Name);
 			}
 
 			logger.info("{} export of {}{} complete in {} seconds.", exportType, branchPath, exportStr, TimerUtil.secondsSince(startTime));
@@ -330,6 +268,96 @@ public class ExportService {
 			throw new ExportException("Failed to write RF2 zip file.", e);
 		} finally {
 			branchService.unlock(branchPath);
+		}
+	}
+
+	private void exportRelationshipsAllTypes(String filenameEffectiveDate, RF2Type exportType, String transientEffectiveTime, String startEffectiveTime, Set<String> moduleIds, BranchCriteria selectionBranchCriteria, String entryDirectoryPrefix, ZipOutputStream zipOutputStream, String codeSystemRF2Name) {
+		// Write Stated Relationships
+		Query relationshipBranchCritera = selectionBranchCriteria.getEntityBranchCriteria(Relationship.class);
+		BoolQuery.Builder relationshipQuery = getContentQuery(exportType, moduleIds, startEffectiveTime, relationshipBranchCritera);
+		relationshipQuery.must(termQuery(Relationship.Fields.CHARACTERISTIC_TYPE_ID, Concepts.STATED_RELATIONSHIP));
+		int statedRelationshipLines = exportComponents(Relationship.class, entryDirectoryPrefix, "Terminology/", "sct2_StatedRelationship_", filenameEffectiveDate, exportType, zipOutputStream,
+				relationshipQuery.build()._toQuery(), transientEffectiveTime, null, codeSystemRF2Name, null);
+		logger.info("{} stated relationship states exported", statedRelationshipLines);
+
+		// Write Inferred non-concrete Relationships
+		relationshipQuery = getContentQuery(exportType, moduleIds, startEffectiveTime, relationshipBranchCritera);
+		// Not 'stated' will include inferred and additional
+		relationshipQuery.mustNot(termQuery(Relationship.Fields.CHARACTERISTIC_TYPE_ID, Concepts.STATED_RELATIONSHIP));
+		relationshipQuery.must(existsQuery(Relationship.Fields.DESTINATION_ID));
+		int inferredRelationshipLines = exportComponents(Relationship.class, entryDirectoryPrefix, "Terminology/", "sct2_Relationship_", filenameEffectiveDate, exportType, zipOutputStream,
+				relationshipQuery.build()._toQuery(), transientEffectiveTime, null, codeSystemRF2Name, null);
+		logger.info("{} inferred (non-concrete) and additional relationship states exported", inferredRelationshipLines);
+
+		// Write Concrete Inferred Relationships
+		relationshipQuery = getContentQuery(exportType, moduleIds, startEffectiveTime, relationshipBranchCritera);
+		relationshipQuery.must(termQuery(Relationship.Fields.CHARACTERISTIC_TYPE_ID, Concepts.INFERRED_RELATIONSHIP));
+		relationshipQuery.must(existsQuery(Relationship.Fields.VALUE));
+		int inferredConcreteRelationshipLines = exportComponents(Relationship.class, entryDirectoryPrefix, "Terminology/", "sct2_RelationshipConcreteValues_", filenameEffectiveDate, exportType,
+				zipOutputStream,
+				relationshipQuery.build()._toQuery(), transientEffectiveTime, null, codeSystemRF2Name, null);
+		logger.info("{} concrete inferred relationship states exported", inferredConcreteRelationshipLines);
+	}
+
+	private void exportIdentifiers(String filenameEffectiveDate, RF2Type exportType, String transientEffectiveTime, String startEffectiveTime, Set<String> moduleIds, BranchCriteria selectionBranchCriteria, String entryDirectoryPrefix, ZipOutputStream zipOutputStream, String codeSystemRF2Name) {
+		BoolQuery.Builder identifierContentQuery = getContentQuery(exportType, moduleIds, startEffectiveTime, selectionBranchCriteria.getEntityBranchCriteria(Identifier.class));
+		int identifierLines = exportComponents(Identifier.class, entryDirectoryPrefix, "Terminology/", "sct2_Identifier_", filenameEffectiveDate, exportType, zipOutputStream,
+				identifierContentQuery.build()._toQuery(), transientEffectiveTime, null, codeSystemRF2Name, null);
+		logger.info("{} identifier states exported", identifierLines);
+	}
+
+	private void exportRefsetMembers(String branchPath, String filenameEffectiveDate, RF2Type exportType, boolean forClassification, boolean languageOnly, String transientEffectiveTime,
+			String startEffectiveTime, Set<String> moduleIds, Set<String> refsetIds, BranchCriteria allContentBranchCriteria, BranchCriteria selectionBranchCriteria, boolean refsetOnlyExport, String entryDirectoryPrefix, ZipOutputStream zipOutputStream, String codeSystemRF2Name) {
+
+		List<ReferenceSetType> referenceSetTypes = getReferenceSetTypes(allContentBranchCriteria.getEntityBranchCriteria(ReferenceSetType.class)).stream()
+				.filter(type -> !forClassification || refsetTypesRequiredForClassification.contains(type.getConceptId()))
+				.filter(type -> !languageOnly || LANG_REFSET.equals(type.getConceptId()))
+				.toList();
+
+		logger.info("{} Reference Set Types found for this export: {}", referenceSetTypes.size(), referenceSetTypes);
+
+		Query memberBranchCriteria = selectionBranchCriteria.getEntityBranchCriteria(ReferenceSetMember.class);
+		for (ReferenceSetType referenceSetType : referenceSetTypes) {
+			List<Long> refsetsOfThisType = new ArrayList<>(queryService.findDescendantIdsAsUnion(allContentBranchCriteria, true, Collections.singleton(Long.parseLong(referenceSetType.getConceptId()))));
+			refsetsOfThisType.add(Long.parseLong(referenceSetType.getConceptId()));
+			for (Long refsetToExport : refsetsOfThisType) {
+				exportRefset(branchPath, filenameEffectiveDate, exportType, transientEffectiveTime, startEffectiveTime, moduleIds, refsetIds, refsetOnlyExport, entryDirectoryPrefix, zipOutputStream, codeSystemRF2Name, referenceSetType, refsetToExport, memberBranchCriteria, refsetsOfThisType);
+			}
+		}
+	}
+
+	private void exportRefset(String branchPath, String filenameEffectiveDate, RF2Type exportType, String transientEffectiveTime,
+			String startEffectiveTime, Set<String> moduleIds, Set<String> refsetIds, boolean refsetOnlyExport, String entryDirectoryPrefix,
+			ZipOutputStream zipOutputStream, String codeSystemRF2Name, ReferenceSetType referenceSetType, Long refsetToExport, Query memberBranchCriteria,
+			List<Long> refsetsOfThisType) {
+
+		if (!refsetOnlyExport || refsetIds.contains(refsetToExport.toString())) {
+			if (Concepts.MODULE_DEPENDENCY_REFERENCE_SET.equals(String.valueOf(refsetToExport))) {
+				moduleIds.addAll(sBranchService.getModules(branchPath));
+			}
+
+			BoolQuery.Builder memberQueryBuilder = getContentQuery(exportType, moduleIds, startEffectiveTime, memberBranchCriteria);
+			memberQueryBuilder.must(termQuery(ReferenceSetMember.Fields.REFSET_ID, refsetToExport));
+			Query memberQuery = memberQueryBuilder.build()._toQuery();
+			long memberCount = elasticsearchOperations.count(getNativeSearchQuery(memberQuery), ReferenceSetMember.class);
+			if (memberCount > 0) {
+				logger.info("Exporting Reference Set {} {} with {} members", refsetToExport, referenceSetType.getName(), memberCount);
+				String exportDir = referenceSetType.getExportDir();
+				String entryDirectory = !exportDir.startsWith("/") ? "Refset/" + exportDir + "/" : exportDir.substring(1) + "/";
+				String entryFilenamePrefix = (!entryDirectory.startsWith("Terminology/") ? "der2_" : "sct2_") + referenceSetType.getFieldTypes() + "Refset_" + referenceSetType.getName() + (refsetsOfThisType.size() > 1 ? refsetToExport : "");
+				exportComponents(
+						ReferenceSetMember.class,
+						entryDirectoryPrefix, entryDirectory,
+						entryFilenamePrefix,
+						filenameEffectiveDate,
+						exportType,
+						zipOutputStream,
+						memberQuery,
+						transientEffectiveTime,
+						referenceSetType.getFieldNameList(),
+						codeSystemRF2Name,
+						null);
+			}
 		}
 	}
 
@@ -389,6 +417,7 @@ public class ExportService {
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	private <T> ExportWriter<T> getExportWriter(Class<T> componentClass, OutputStream outputStream, List<String> extraFieldNames, boolean concrete) {
 		if (componentClass.equals(Concept.class)) {
 			return (ExportWriter<T>) new ConceptExportWriter(getBufferedWriter(outputStream));


### PR DESCRIPTION
This PR adds a `languageOnly` flag to the RF2 export configuration, allowing just the Concepts, Descriptions, TextDefinitions and Language Refsets to be exported. When this is combined with a module filter it allows a fast RF2 dump of just the translations from an extension.

This functionality is to support the initialisation, and later synchronisation, of translation content from the Managed Service to the new Translation Tool via the Simplex service.